### PR TITLE
[#43] Revisions to link datasets view

### DIFF
--- a/src/components/DatasetItem.css
+++ b/src/components/DatasetItem.css
@@ -49,7 +49,11 @@
   text-overflow: ellipsis;
 }
 
-.dataset button, .dataset a.btn {
+.link-icon {
   justify-self: flex-end;
   margin-left: auto;
+}
+
+.link-icon .stroke {
+  fill: #c1c1c1;
 }

--- a/src/components/DatasetItem.js
+++ b/src/components/DatasetItem.js
@@ -19,7 +19,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {FormattedDate} from 'react-intl';
-import {Button} from 'react-bootstrap';
 
 import analytics from '../analytics';
 
@@ -37,28 +36,26 @@ class DatasetItem extends Component {
 
   buttonClick = () => {
     analytics.track(`exceladdin.dataset.${this.props.buttonText.toLowerCase()}.click`);
+    if(this.props.buttonLink) {
+      return window.open(this.props.buttonLink);
+    }
     if (this.props.buttonHandler) {
       this.props.buttonHandler(this.props.dataset);
     }
   }
 
   render () {
-    const {dataset, buttonText, buttonLink} = this.props;
-    return (<div className='dataset'>
+    const {dataset} = this.props;
+    return (
+    <div className='dataset' onClick={this.buttonClick}>
       <Icon icon={dataset.isProject ? 'projectSchema' : 'datasetSchema'} />
       <div className='center-info'>
         <div className='title'>{dataset.title}</div>
         <div className='info'>@{dataset.owner} &middot; Updated <FormattedDate value={dataset.updated} year='numeric' month='short' day='2-digit' /></div>
       </div>
-      {!!buttonLink && <Button
-        bsSize='small'
-        href={buttonLink}
-        target='_blank'
-        rel='noopener noreferrer'
-        onClick={this.buttonClick}>{buttonText}</Button>}
-      {!buttonLink && <Button
-        bsSize='small'
-        onClick={this.buttonClick}>{buttonText}</Button>}
+      <div className='link-icon'>
+        <Icon icon='angleRight' />
+      </div>
     </div>)
   }
 }

--- a/src/components/DatasetsView.css
+++ b/src/components/DatasetsView.css
@@ -18,14 +18,20 @@
  */
 .datasets-view .dataset-selector .section-header {
   padding: 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
 }
 
 .datasets-view .dataset-selector .section-header .add-icon {
-  float: right;
-  width: 20px;
-  height: 20px;
-  margin-top: 2px;
+  width: 15px;
+  height: 15px;
+  margin-right: 5px;
   cursor: pointer;
+}
+
+.datasets-view .dataset-selector .section-header .add-icon .stroke {
+  stroke: #4376b2;
 }
 
 .datasets-view .section-header .title {
@@ -39,4 +45,13 @@
   bottom: initial;
   left: initial;
   right: initial;
+}
+
+.datasets-view .dataset-selector .section-header button {
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  color: #4376b2;
+  float: right;
+  font-size: 18px;
 }

--- a/src/components/DatasetsView.js
+++ b/src/components/DatasetsView.js
@@ -114,8 +114,11 @@ class DatasetsView extends Component {
           <Row className='center-block section-header'>
             <div className='title'>
               Select a dataset to link
-              <Icon icon='add' onClick={this.addDatasetClick} />
             </div>
+            <Button onClick={this.addDatasetClick}>
+              <Icon icon='add' />
+              New
+            </Button>
           </Row>
           {loadingDatasets && <LoadingAnimation label='Fetching datasets...' />}
           {!!datasets.length && !loadingDatasets &&

--- a/src/components/LoginHeader.js
+++ b/src/components/LoginHeader.js
@@ -46,7 +46,7 @@ class LoginHeader extends Component {
     return (
       <div className='login-header'>
         <LogoFull />
-        {user && <DropdownButton title={user.id} pullRight bsSize='small' onSelect={this.userMenuChanged} id='dropdown-user'>
+        {user && <DropdownButton title={`@${user.id}`} pullRight bsSize='small' onSelect={this.userMenuChanged} id='dropdown-user'>
           <MenuItem eventKey='signout'>Sign out</MenuItem>
         </DropdownButton>}
       </div>

--- a/src/components/icons/Icon.js
+++ b/src/components/icons/Icon.js
@@ -26,6 +26,18 @@ const datasetSchema = <svg className='dataset-schema-icon' xmlns='http://www.w3.
 const projectSchema = <svg className='project-schema-icon' version='1.1' xmlns='http://www.w3.org/2000/svg' x='0px' y='0px' viewBox='0 0 16 16'>
   <path className='fill' d='M15,0H1C0.4,0,0,0.4,0,1v14c0,0.6,0.4,1,1,1h14c0.6,0,1-0.4,1-1V1C16,0.4,15.6,0,15,0z M13.6,6.3l-2.3,3.5c-0.3,0.6-1.3,0.7-1.7,0.2L7,7.5l-2.7,3.6c-0.3,0.5-1.2,0.6-1.6,0.2C2.2,11,2.1,10.1,2.4,9.7L5.9,5c0.5-0.6,1.3-0.6,1.7-0.1l2.4,2.4L11.6,5c0.3-0.6,1-0.7,1.6-0.3C13.8,5,13.9,5.7,13.6,6.3z'/>
 </svg>;
+const angleRight =
+<svg
+  className='angle-right'
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 40 40"
+  width="40" height="40"
+>
+  <path
+    className='stroke'
+    d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+  />
+ </svg>
 
 
 const add = <svg className='add-icon' version='1.1' xmlns='http://www.w3.org/2000/svg' x='0px' y='0px' viewBox='0 0 16 16'>
@@ -64,7 +76,7 @@ const warning = <svg className='warning-icon' width='16' height='16' viewBox='0 
 
 
 const ICONS = {
-  add, check, close, datasetSchema, projectSchema, sync, warning
+  add, check, close, datasetSchema, projectSchema, sync, warning, angleRight
 };
 
 export default class Icon extends Component {

--- a/src/tests/components/__snapshots__/DatasetItem.spec.js.snap
+++ b/src/tests/components/__snapshots__/DatasetItem.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`renders dataset - as project 1`] = `
 <div
   className="dataset"
+  onClick={[Function]}
 >
   <span
     className="svg-icon "
@@ -41,18 +42,34 @@ exports[`renders dataset - as project 1`] = `
       </span>
     </div>
   </div>
-  <button
-    className="btn btn-sm btn-default"
-    disabled={false}
-    onClick={[Function]}
-    type="button"
-  />
+  <div
+    className="link-icon"
+  >
+    <span
+      className="svg-icon "
+      onClick={undefined}
+    >
+      <svg
+        className="angle-right"
+        height="40"
+        viewBox="0 0 40 40"
+        width="40"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className="stroke"
+          d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+        />
+      </svg>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`renders dataset - button text 1`] = `
 <div
   className="dataset"
+  onClick={[Function]}
 >
   <span
     className="svg-icon "
@@ -88,20 +105,34 @@ exports[`renders dataset - button text 1`] = `
       </span>
     </div>
   </div>
-  <button
-    className="btn btn-sm btn-default"
-    disabled={false}
-    onClick={[Function]}
-    type="button"
+  <div
+    className="link-icon"
   >
-    test
-  </button>
+    <span
+      className="svg-icon "
+      onClick={undefined}
+    >
+      <svg
+        className="angle-right"
+        height="40"
+        viewBox="0 0 40 40"
+        width="40"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className="stroke"
+          d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+        />
+      </svg>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`renders dataset - button text, link 1`] = `
 <div
   className="dataset"
+  onClick={[Function]}
 >
   <span
     className="svg-icon "
@@ -137,21 +168,34 @@ exports[`renders dataset - button text, link 1`] = `
       </span>
     </div>
   </div>
-  <a
-    className="btn btn-sm btn-default"
-    href="https://data.world"
-    onClick={[Function]}
-    rel="noopener noreferrer"
-    target="_blank"
+  <div
+    className="link-icon"
   >
-    test
-  </a>
+    <span
+      className="svg-icon "
+      onClick={undefined}
+    >
+      <svg
+        className="angle-right"
+        height="40"
+        viewBox="0 0 40 40"
+        width="40"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className="stroke"
+          d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+        />
+      </svg>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`renders dataset 1`] = `
 <div
   className="dataset"
+  onClick={[Function]}
 >
   <span
     className="svg-icon "
@@ -187,11 +231,26 @@ exports[`renders dataset 1`] = `
       </span>
     </div>
   </div>
-  <button
-    className="btn btn-sm btn-default"
-    disabled={false}
-    onClick={[Function]}
-    type="button"
-  />
+  <div
+    className="link-icon"
+  >
+    <span
+      className="svg-icon "
+      onClick={undefined}
+    >
+      <svg
+        className="angle-right"
+        height="40"
+        viewBox="0 0 40 40"
+        width="40"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className="stroke"
+          d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+        />
+      </svg>
+    </span>
+  </div>
 </div>
 `;

--- a/src/tests/components/__snapshots__/DatasetsView.spec.js.snap
+++ b/src/tests/components/__snapshots__/DatasetsView.spec.js.snap
@@ -14,9 +14,16 @@ exports[`renders datasets view - datasets 1`] = `
         className="title"
       >
         Select a dataset to link
+      </div>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
         <span
           className="svg-icon "
-          onClick={[Function]}
+          onClick={undefined}
         >
           <svg
             className="add-icon"
@@ -44,7 +51,8 @@ exports[`renders datasets view - datasets 1`] = `
             </g>
           </svg>
         </span>
-      </div>
+        New
+      </button>
     </div>
     <div
       className="center-block row"
@@ -311,6 +319,7 @@ exports[`renders datasets view - datasets 1`] = `
       <div>
         <div
           className="dataset"
+          onClick={[Function]}
         >
           <span
             className="svg-icon "
@@ -346,17 +355,31 @@ exports[`renders datasets view - datasets 1`] = `
               </span>
             </div>
           </div>
-          <button
-            className="btn btn-sm btn-default"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            className="link-icon"
           >
-            Link
-          </button>
+            <span
+              className="svg-icon "
+              onClick={undefined}
+            >
+              <svg
+                className="angle-right"
+                height="40"
+                viewBox="0 0 40 40"
+                width="40"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className="stroke"
+                  d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
         <div
           className="dataset"
+          onClick={[Function]}
         >
           <span
             className="svg-icon "
@@ -395,17 +418,31 @@ exports[`renders datasets view - datasets 1`] = `
               </span>
             </div>
           </div>
-          <button
-            className="btn btn-sm btn-default"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            className="link-icon"
           >
-            Link
-          </button>
+            <span
+              className="svg-icon "
+              onClick={undefined}
+            >
+              <svg
+                className="angle-right"
+                height="40"
+                viewBox="0 0 40 40"
+                width="40"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className="stroke"
+                  d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
         <div
           className="dataset"
+          onClick={[Function]}
         >
           <span
             className="svg-icon "
@@ -441,14 +478,27 @@ exports[`renders datasets view - datasets 1`] = `
               </span>
             </div>
           </div>
-          <button
-            className="btn btn-sm btn-default"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            className="link-icon"
           >
-            Link
-          </button>
+            <span
+              className="svg-icon "
+              onClick={undefined}
+            >
+              <svg
+                className="angle-right"
+                height="40"
+                viewBox="0 0 40 40"
+                width="40"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className="stroke"
+                  d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
         <button
           className="bottom-button btn btn-default"
@@ -478,9 +528,16 @@ exports[`renders datasets view - loading state 1`] = `
         className="title"
       >
         Select a dataset to link
+      </div>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
         <span
           className="svg-icon "
-          onClick={[Function]}
+          onClick={undefined}
         >
           <svg
             className="add-icon"
@@ -508,7 +565,8 @@ exports[`renders datasets view - loading state 1`] = `
             </g>
           </svg>
         </span>
-      </div>
+        New
+      </button>
     </div>
     <div
       className="loaderoverlay"
@@ -546,9 +604,16 @@ exports[`renders datasets view - no datasets 1`] = `
         className="title"
       >
         Select a dataset to link
+      </div>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
         <span
           className="svg-icon "
-          onClick={[Function]}
+          onClick={undefined}
         >
           <svg
             className="add-icon"
@@ -576,7 +641,8 @@ exports[`renders datasets view - no datasets 1`] = `
             </g>
           </svg>
         </span>
-      </div>
+        New
+      </button>
     </div>
     <div
       className="center-block no-datasets row"

--- a/src/tests/components/__snapshots__/LoginHeader.spec.js.snap
+++ b/src/tests/components/__snapshots__/LoginHeader.spec.js.snap
@@ -759,7 +759,7 @@ exports[`renders login header - with user 1`] = `
       role="button"
       type="button"
     >
-      test
+      @test
        
       <span
         className="caret"

--- a/src/tests/components/__snapshots__/WelcomePage.spec.js.snap
+++ b/src/tests/components/__snapshots__/WelcomePage.spec.js.snap
@@ -799,6 +799,7 @@ exports[`renders welcome page - with dataset 1`] = `
       </div>
       <div
         className="dataset"
+        onClick={[Function]}
       >
         <span
           className="svg-icon "
@@ -834,15 +835,27 @@ exports[`renders welcome page - with dataset 1`] = `
             </span>
           </div>
         </div>
-        <a
-          className="btn btn-sm btn-default"
-          href="https://data.world/test/test"
-          onClick={[Function]}
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          className="link-icon"
         >
-          View
-        </a>
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-right"
+              height="40"
+              viewBox="0 0 40 40"
+              width="40"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.3 21.4q0 0.3-0.2 0.5l-10.4 10.4q-0.3 0.3-0.6 0.3t-0.5-0.3l-1.1-1.1q-0.2-0.2-0.2-0.5t0.2-0.5l8.8-8.8-8.8-8.7q-0.2-0.3-0.2-0.6t0.2-0.5l1.1-1.1q0.3-0.2 0.5-0.2t0.6 0.2l10.4 10.4q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
       <div
         className="message"


### PR DESCRIPTION
Addresses #43 

**What the PR changes**
1. Adds the `@` symbol before the username on the header.
2. Adds the text `New` to the add icon on the link datasets page.
3. Replaces the link button on the link datasets page with an icon. In addition it makes the entire dataset list item clickable as would be expected by users when they see the angle right icon.
4. Handles opening of dataset urls with `window.open`
4. Updates test snapshots.