### PR TITLE
[#44] Revisions to 'Dataset/Add Files' View

### DIFF
--- a/src/components/BindingListItem.css
+++ b/src/components/BindingListItem.css
@@ -78,6 +78,9 @@
   height: 2rem;
   width: 2rem;
   min-width: 2rem;
+  border: 0;
+  border: 1px solid #cbcbcb;
+  box-shadow: none;
 }
 
 .file .add-button .svg-icon {
@@ -98,15 +101,18 @@
 }
 
 .file .link-button {
-  border: none;
-  box-shadow: none;
-  padding: 0;
+  display: flex;
+  justify-content: center;
   width: 2rem;
+  padding: 0;
+  border: 1px solid #5ab962;
+  border-radius: 50%;
+  box-shadow: none;
+  height: 2rem;
 }
 
 .file .link-button span {
-  display: block;
-  float: none;
+  display: flex;
 }
 
 .file .link-button .label {
@@ -117,18 +123,16 @@
   color: #65c16d;
 }
 
-.file .link-button .unlink {
-  display: none;
-}
-
-.file .link-button .unlink .label {
-  color: #ff6666;
-}
-
 .file .link-button svg.check-icon .stroke {
   stroke: #65c16d;
   fill: #fff;
 }
+
+.file svg.add-icon .stroke {
+  stroke: #cbcbcb;
+  fill: #fff;
+}
+
 .file .link-button svg.close-icon {
   width: 12px;
 }
@@ -139,10 +143,6 @@
 
 .file .link-button:hover .unlink {
   display: block;
-}
-
-.file .link-button:hover .link {
-  display: none;
 }
 
 .file .file-icon {

--- a/src/components/BindingListItem.js
+++ b/src/components/BindingListItem.js
@@ -92,15 +92,9 @@ class BindingsListItem extends Component {
           onClick={this.addClick}><Icon icon='add' /></Button>}
         {!!binding && !isSyncing && <Button
           bsSize='small'
-          className='link-button'
-          onClick={this.removeClick}>
+          className='link-button'>
             <div className='link'>
               <Icon className='check' icon='check' />
-              <span className='label'>Linked</span>
-            </div>
-            <div className='unlink'>
-              <Icon icon='close' />
-              <span className='label'>Unlink</span>
             </div>
           </Button>}
           {!!binding && isSyncing && <div className='loader-icon'></div>}

--- a/src/components/BindingsPage.css
+++ b/src/components/BindingsPage.css
@@ -62,13 +62,51 @@
   border-top: 1px solid #dfe3e9;
 }
 
+.bindings-page .section-header .title {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 15px;
+}
+
+.bindings-page .section-header .link {
+  color: #4376b2;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.bindings-page .section-header .title .link {
+  display: flex;
+}
+
+.bindings-page svg.angle-left-icon .stroke {
+  fill: #4376b2;
+}
+
+.bindings-page .section-header .button-link {
+  font-size: 14px;
+}
+
+.bindings-page .section-header .title .dropdown {
+  display: flex;
+}
+
+.bindings-page .section-header .title .dataset-title {
+  font-weight:  bold;
+  line-height: 2em;
+}
+
+.bindings-page .section-header .button-group {
+  display: flex;
+  justify-content: space-between;
+}
+
 .bindings-page .section-header .button-group button {
-  width: 50%;
   border: none;
   box-shadow: none;
-  padding: 0 1.5rem;
+  padding: 0 10px;
   height: 2rem;
   color: #4376b2;
+  font-size: 14px;
 }
 
 .bindings-page .section-header .button-group button .badge {
@@ -79,12 +117,9 @@
   background-color: transparent;
 }
 
-.bindings-page .section-header .button-group button:first-child {
+.bindings-page .section-header .button-group button:nth-child(even) {
   border-right: 1px solid #dfe3e9;
-}
-
-.bindings-page .dataset-link {
-  margin-bottom: 1rem;
+  border-left: 1px solid #dfe3e9;
 }
 
 .bindings-page .section-header a {

--- a/src/components/BindingsPage.js
+++ b/src/components/BindingsPage.js
@@ -157,8 +157,16 @@ class BindingsPage extends Component {
       <Grid className='bindings-page'>
         <Row className='center-block section-header'>
           <div className='title'>
-            {dataset.title}
-            <Dropdown id='dropdown-dataset-options' className='pull-right' pullRight>
+            <div>
+              <div className='link' onClick={this.props.unlinkDataset}>
+                <Icon icon='angleLeft' />
+                Change linked dataset
+              </div>
+              <div className='dataset-title'>
+                {`${dataset.title} dataset`}
+              </div>
+            </div>
+            <Dropdown id='dropdown-dataset-options' className='dropdown' pullRight>
               <Dropdown.Toggle noCaret >
                 <Glyphicon glyph='option-vertical' />
               </Dropdown.Toggle>
@@ -166,9 +174,6 @@ class BindingsPage extends Component {
                 <MenuItem eventKey='unlink'>Unlink</MenuItem>
               </Dropdown.Menu>
             </Dropdown>
-          </div>
-          <div className='dataset-link'>
-            <a href={`https://data.world/${dataset.owner}/${dataset.id}`} target='_blank'>https://data.world/{dataset.owner}/{dataset.id}</a>
           </div>
           <div className='button-group'>
             <Button onClick={this.addFile}>
@@ -184,6 +189,15 @@ class BindingsPage extends Component {
               <div className='loader-icon'></div>
               Syncing…
               </Button>}
+            <Button>
+              <a
+                href={`https://data.world/${dataset.owner}/${dataset.id}`}
+                target='_blank'
+                className='link button-link'
+              >
+                View on Web
+              </a>
+            </Button>
           </div>
         </Row>
         {!!bindingEntries.length && canEdit &&
@@ -208,9 +222,8 @@ class BindingsPage extends Component {
         {!bindingEntries.length && canEdit &&
           <Row className='center-block no-datasets'>
             <div className='message'>
-              You haven't added any data to this dataset.
+              You haven't added any files to this dataset
             </div>
-            <Button className='bottom-button' bsStyle='primary' onClick={this.addFile}>Add data</Button>
           </Row>}
         {!canEdit &&
           <Row className='center-block no-datasets'>
@@ -225,6 +238,9 @@ class BindingsPage extends Component {
               Request access
             </Button>
           </Row>}
+          <Row className='center-block'>
+            <Button className='bottom-button' bsStyle='primary' onClick={this.addFile}>New File</Button>
+          </Row>
       </Grid>
     );
   }

--- a/src/components/icons/Icon.js
+++ b/src/components/icons/Icon.js
@@ -61,10 +61,24 @@ const warning = <svg className='warning-icon' width='16' height='16' viewBox='0 
   </g>
 </svg>
 
+const angleLeft =
+  <svg
+    className='angle-left-icon'
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 40 40"
+  >
+    <path
+      className='stroke'
+      d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+    />
+  </svg>
+
 
 
 const ICONS = {
-  add, check, close, datasetSchema, projectSchema, sync, warning
+  add, check, close, datasetSchema, projectSchema, sync, warning, angleLeft
 };
 
 export default class Icon extends Component {

--- a/src/tests/components/__snapshots__/BindingsPage.spec.js.snap
+++ b/src/tests/components/__snapshots__/BindingsPage.spec.js.snap
@@ -10,9 +10,38 @@ exports[`renders binding page - insufficient access 1`] = `
     <div
       className="title"
     >
-      This is a test
+      <div>
+        <div
+          className="link"
+          onClick={undefined}
+        >
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-left-icon"
+              height="20"
+              viewBox="0 0 40 40"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+          Change linked dataset
+        </div>
+        <div
+          className="dataset-title"
+        >
+          This is a test dataset
+        </div>
+      </div>
       <div
-        className="pull-right dropdown btn-group"
+        className="dropdown dropdown btn-group"
       >
         <button
           aria-expanded={false}
@@ -51,19 +80,6 @@ exports[`renders binding page - insufficient access 1`] = `
           </li>
         </ul>
       </div>
-    </div>
-    <div
-      className="dataset-link"
-    >
-      <a
-        href="https://data.world/test/test"
-        target="_blank"
-      >
-        https://data.world/
-        test
-        /
-        test
-      </a>
     </div>
     <div
       className="button-group"
@@ -138,6 +154,19 @@ exports[`renders binding page - insufficient access 1`] = `
           </svg>
         </span>
         Save Files
+      </button>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        <a
+          className="link button-link"
+          href="https://data.world/test/test"
+          target="_blank"
+        >
+          View on Web
+        </a>
       </button>
     </div>
   </div>
@@ -159,6 +188,18 @@ exports[`renders binding page - insufficient access 1`] = `
       Request access
     </a>
   </div>
+  <div
+    className="center-block row"
+  >
+    <button
+      className="bottom-button btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      New File
+    </button>
+  </div>
 </div>
 `;
 
@@ -172,9 +213,38 @@ exports[`renders bindings page - dataset with files 1`] = `
     <div
       className="title"
     >
-      This is a test
+      <div>
+        <div
+          className="link"
+          onClick={undefined}
+        >
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-left-icon"
+              height="20"
+              viewBox="0 0 40 40"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+          Change linked dataset
+        </div>
+        <div
+          className="dataset-title"
+        >
+          This is a test dataset
+        </div>
+      </div>
       <div
-        className="pull-right dropdown btn-group"
+        className="dropdown dropdown btn-group"
       >
         <button
           aria-expanded={false}
@@ -213,19 +283,6 @@ exports[`renders bindings page - dataset with files 1`] = `
           </li>
         </ul>
       </div>
-    </div>
-    <div
-      className="dataset-link"
-    >
-      <a
-        href="https://data.world/test/test"
-        target="_blank"
-      >
-        https://data.world/
-        test
-        /
-        test
-      </a>
     </div>
     <div
       className="button-group"
@@ -300,6 +357,19 @@ exports[`renders bindings page - dataset with files 1`] = `
           </svg>
         </span>
         Save Files
+      </button>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        <a
+          className="link button-link"
+          href="https://data.world/test/test"
+          target="_blank"
+        >
+          View on Web
+        </a>
       </button>
     </div>
   </div>
@@ -748,6 +818,18 @@ exports[`renders bindings page - dataset with files 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="center-block row"
+  >
+    <button
+      className="bottom-button btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      New File
+    </button>
+  </div>
 </div>
 `;
 
@@ -761,9 +843,38 @@ exports[`renders bindings page - dataset with files, bindings 1`] = `
     <div
       className="title"
     >
-      This is a test
+      <div>
+        <div
+          className="link"
+          onClick={undefined}
+        >
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-left-icon"
+              height="20"
+              viewBox="0 0 40 40"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+          Change linked dataset
+        </div>
+        <div
+          className="dataset-title"
+        >
+          This is a test dataset
+        </div>
+      </div>
       <div
-        className="pull-right dropdown btn-group"
+        className="dropdown dropdown btn-group"
       >
         <button
           aria-expanded={false}
@@ -802,19 +913,6 @@ exports[`renders bindings page - dataset with files, bindings 1`] = `
           </li>
         </ul>
       </div>
-    </div>
-    <div
-      className="dataset-link"
-    >
-      <a
-        href="https://data.world/test/test"
-        target="_blank"
-      >
-        https://data.world/
-        test
-        /
-        test
-      </a>
     </div>
     <div
       className="button-group"
@@ -889,6 +987,19 @@ exports[`renders bindings page - dataset with files, bindings 1`] = `
           </svg>
         </span>
         Save Files
+      </button>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        <a
+          className="link button-link"
+          href="https://data.world/test/test"
+          target="_blank"
+        >
+          View on Web
+        </a>
       </button>
     </div>
   </div>
@@ -1310,7 +1421,6 @@ exports[`renders bindings page - dataset with files, bindings 1`] = `
         <button
           className="link-button btn btn-sm btn-default"
           disabled={false}
-          onClick={[Function]}
           type="button"
         >
           <div
@@ -1338,41 +1448,22 @@ exports[`renders bindings page - dataset with files, bindings 1`] = `
                 </g>
               </svg>
             </span>
-            <span
-              className="label"
-            >
-              Linked
-            </span>
-          </div>
-          <div
-            className="unlink"
-          >
-            <span
-              className="svg-icon "
-              onClick={undefined}
-            >
-              <svg
-                className="close-icon"
-                height="15"
-                viewBox="0 0 16 15"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  className="stroke stroke-medium"
-                  d="M15.222 14.222L1 0M1 14.222L15.222 0"
-                />
-              </svg>
-            </span>
-            <span
-              className="label"
-            >
-              Unlink
-            </span>
           </div>
         </button>
       </div>
     </div>
+  </div>
+  <div
+    className="center-block row"
+  >
+    <button
+      className="bottom-button btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      New File
+    </button>
   </div>
 </div>
 `;
@@ -1387,9 +1478,38 @@ exports[`renders bindings page - syncing 1`] = `
     <div
       className="title"
     >
-      This is a test
+      <div>
+        <div
+          className="link"
+          onClick={undefined}
+        >
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-left-icon"
+              height="20"
+              viewBox="0 0 40 40"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+          Change linked dataset
+        </div>
+        <div
+          className="dataset-title"
+        >
+          This is a test dataset
+        </div>
+      </div>
       <div
-        className="pull-right dropdown btn-group"
+        className="dropdown dropdown btn-group"
       >
         <button
           aria-expanded={false}
@@ -1428,19 +1548,6 @@ exports[`renders bindings page - syncing 1`] = `
           </li>
         </ul>
       </div>
-    </div>
-    <div
-      className="dataset-link"
-    >
-      <a
-        href="https://data.world/test/test"
-        target="_blank"
-      >
-        https://data.world/
-        test
-        /
-        test
-      </a>
     </div>
     <div
       className="button-group"
@@ -1492,6 +1599,19 @@ exports[`renders bindings page - syncing 1`] = `
           className="loader-icon"
         />
         Syncing…
+      </button>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        <a
+          className="link button-link"
+          href="https://data.world/test/test"
+          target="_blank"
+        >
+          View on Web
+        </a>
       </button>
     </div>
   </div>
@@ -1904,6 +2024,18 @@ exports[`renders bindings page - syncing 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="center-block row"
+  >
+    <button
+      className="bottom-button btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      New File
+    </button>
+  </div>
 </div>
 `;
 
@@ -1917,9 +2049,38 @@ exports[`renders bindings page 1`] = `
     <div
       className="title"
     >
-      This is a test
+      <div>
+        <div
+          className="link"
+          onClick={undefined}
+        >
+          <span
+            className="svg-icon "
+            onClick={undefined}
+          >
+            <svg
+              className="angle-left-icon"
+              height="20"
+              viewBox="0 0 40 40"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="stroke"
+                d="m26.5 12.1q0 0.3-0.2 0.6l-8.8 8.7 8.8 8.8q0.2 0.2 0.2 0.5t-0.2 0.5l-1.1 1.1q-0.3 0.3-0.6 0.3t-0.5-0.3l-10.4-10.4q-0.2-0.2-0.2-0.5t0.2-0.5l10.4-10.4q0.3-0.2 0.5-0.2t0.6 0.2l1.1 1.1q0.2 0.2 0.2 0.5z"
+              />
+            </svg>
+          </span>
+          Change linked dataset
+        </div>
+        <div
+          className="dataset-title"
+        >
+          This is a test dataset
+        </div>
+      </div>
       <div
-        className="pull-right dropdown btn-group"
+        className="dropdown dropdown btn-group"
       >
         <button
           aria-expanded={false}
@@ -1958,19 +2119,6 @@ exports[`renders bindings page 1`] = `
           </li>
         </ul>
       </div>
-    </div>
-    <div
-      className="dataset-link"
-    >
-      <a
-        href="https://data.world/test/test"
-        target="_blank"
-      >
-        https://data.world/
-        test
-        /
-        test
-      </a>
     </div>
     <div
       className="button-group"
@@ -2046,6 +2194,19 @@ exports[`renders bindings page 1`] = `
         </span>
         Save Files
       </button>
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        <a
+          className="link button-link"
+          href="https://data.world/test/test"
+          target="_blank"
+        >
+          View on Web
+        </a>
+      </button>
     </div>
   </div>
   <div
@@ -2054,15 +2215,19 @@ exports[`renders bindings page 1`] = `
     <div
       className="message"
     >
-      You haven't added any data to this dataset.
+      You haven't added any files to this dataset
     </div>
+  </div>
+  <div
+    className="center-block row"
+  >
     <button
       className="bottom-button btn btn-primary"
       disabled={false}
       onClick={[Function]}
       type="button"
     >
-      Add data
+      New File
     </button>
   </div>
 </div>


### PR DESCRIPTION
Addresses #44 

**What the PR changes**

1. Removes the URL to the project
2. Adds a link ('Change linked dataset') back to the 'Select a dataset to
link' view
3. Updates the button bar to have (3) buttons instead of 2: 'New File',
'Save', 'View on Web'
4. Changes bottom button text from 'Add data' to 'New file' and have it
always displayed.
5. Changes the placeholder text from 'You haven't added any data to this
dataset' to 'You haven't added any files to this dataset.
6.  Removes the 'Unlink' hover state, remove 'linked' text from button.
7. Changes colour of add button to grey
7. Updates test snapshots.

**What is not covered**
1. Navigating to list of all datasets without removing bindings. The changes involved are substantive and are better handled in a separate PR.