### PR TITLE
[#42] Allow users to select a sheet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -421,7 +421,13 @@ class App extends Component {
   showAddData = (filename, binding) => {
 
     if (binding) {
-      this.office.select(binding.rangeAddress);
+      const maxRows = 1048576;
+      const maxColumns = 150;
+
+      // Select non sheet binding range
+      if (binding.rowCount !== maxRows && binding.columnCount !== maxColumns) {
+        this.office.select(binding.rangeAddress);
+      }
     }
 
     // Listen for changes to the selected range

--- a/src/App.js
+++ b/src/App.js
@@ -168,9 +168,6 @@ class App extends Component {
 
   async createBinding (selection) {
     await this.office.createSelectionRange(selection.name, selection.sheet, selection.range)
-
-    // Temporary workaround: The last namedItem added is not visible so we have to add twice 
-    await this.office.createSelectionRange(selection.name + "Temp", selection.sheet, selection.range)
     try {
       const binding = await this.office.createBinding(selection.name);
       if (binding.columnCount > MAXIMUM_COLUMNS) {

--- a/src/App.js
+++ b/src/App.js
@@ -166,9 +166,13 @@ class App extends Component {
     });
   }
 
-  async createBinding (filename) {
+  async createBinding (selection) {
+    await this.office.createSelectionRange(selection.name, selection.sheet, selection.range)
+
+    // Temporary workaround: The last namedItem added is not visible so we have to add twice 
+    await this.office.createSelectionRange(selection.name + "Temp", selection.sheet, selection.range)
     try {
-      const binding = await this.office.createBinding(filename);
+      const binding = await this.office.createBinding(selection.name);
       if (binding.columnCount > MAXIMUM_COLUMNS) {
         await this.office.removeBinding(binding);
         throw new Error(`The maximum number of columns is ${MAXIMUM_COLUMNS}.  If you need to bind to more columns than that, please upload your Excel file to data.world directly. `);
@@ -298,10 +302,10 @@ class App extends Component {
    * There is not currently a way to update the range for an existing binding
    * in the office API.
    */
-  async updateBinding (binding, filename) {
+  async updateBinding (binding, selection) {
     try {
       await this.removeBinding(binding);
-      return this.createBinding(filename);
+      return this.createBinding(selection);
     } catch (error) {
       this.setState({ error });
     }

--- a/src/App.js
+++ b/src/App.js
@@ -320,6 +320,54 @@ class App extends Component {
   }
 
   /**
+   * Removes blank rows and columns around the data
+   */
+  trimFile = (grid) => {
+    const numberOfRows = grid.length;
+    const numberOfColumns = grid[0].length;
+
+    // Rows and columns where the data starts and ends
+    const paramaters = {
+      firstRow: numberOfRows,
+      lastRow: 0,
+      firstColumn: numberOfColumns,
+      lastColumn: 0
+    }
+
+    for (let row = 0; row < numberOfRows; row++) {
+      for (let column = 0; column < numberOfColumns; column++) {
+
+        // If current cell contains data
+        if (grid[row][column]) {
+          if (row < paramaters.firstRow) {
+            paramaters.firstRow = row
+          }
+          if (row > paramaters.lastRow) {
+            paramaters.lastRow = row
+          }
+
+          if (column < paramaters.firstColumn) {
+            paramaters.firstColumn = column
+          }
+
+          if (column > paramaters.lastColumn) {
+            paramaters.lastColumn = column
+          }
+        }
+      }
+    }
+
+    // Remove blank rows and columns
+    const trimmedRows = grid.slice(paramaters.firstRow, paramaters.lastRow + 1);
+    const trimmedColumns = trimmedRows.map(row => {
+      return row.slice(paramaters.firstColumn, paramaters.lastColumn + 1);
+    })
+
+    const result = trimmedColumns.length > 0 ? trimmedColumns : [['']]
+    return result;
+  }
+
+  /**
    * Saves bindings to their associated files on data.world.  If a binding
    * is provided, then only that binding is saved to data.world.
    */
@@ -331,8 +379,9 @@ class App extends Component {
       bindings.forEach((binding) => {
         const promise = new Promise((resolve, reject) => {
           this.office.getData(binding).then((data) => {
+            const trimmedData = this.trimFile(data);
             return this.api.uploadFile({
-              data,
+              data: trimmedData,
               dataset: this.state.dataset,
               filename: binding.id.replace('dw::', '')
             });

--- a/src/App.js
+++ b/src/App.js
@@ -167,7 +167,7 @@ class App extends Component {
   }
 
   async createBinding (selection) {
-    const namedItem = await this.office.createSelectionRange(selection.name, selection.sheet, selection.range)
+    const namedItem = await this.office.createSelectionRange(selection.sheet, selection.range)
     try {
       const binding = await this.office.createBinding(selection.name, namedItem);
       if (binding.columnCount > MAXIMUM_COLUMNS) {

--- a/src/App.js
+++ b/src/App.js
@@ -167,9 +167,9 @@ class App extends Component {
   }
 
   async createBinding (selection) {
-    await this.office.createSelectionRange(selection.name, selection.sheet, selection.range)
+    const namedItem = await this.office.createSelectionRange(selection.name, selection.sheet, selection.range)
     try {
-      const binding = await this.office.createBinding(selection.name);
+      const binding = await this.office.createBinding(selection.name, namedItem);
       if (binding.columnCount > MAXIMUM_COLUMNS) {
         await this.office.removeBinding(binding);
         throw new Error(`The maximum number of columns is ${MAXIMUM_COLUMNS}.  If you need to bind to more columns than that, please upload your Excel file to data.world directly. `);

--- a/src/App.js
+++ b/src/App.js
@@ -427,6 +427,10 @@ class App extends Component {
       // Select non sheet binding range
       if (binding.rowCount !== maxRows && binding.columnCount !== maxColumns) {
         this.office.select(binding.rangeAddress);
+      } else {
+        // Display the bound sheet
+        const sheet = binding.rangeAddress.substring(0, binding.rangeAddress.indexOf('!'));
+        this.office.activateSheet(sheet);
       }
     }
 

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -224,6 +224,19 @@ export default class OfficeConnector {
     });
   }
 
+  activateSheet (sheet) {
+    return new Promise((resolve, reject) => {
+      if (!this.isExcelApiSupported()) {
+        return resolve();
+      }
+      Excel.run(function (ctx) {
+        var worksheet = ctx.workbook.worksheets.getItem(sheet);
+        worksheet.activate();
+        return ctx.sync().then(resolve);
+      });;
+    });
+  }
+
   getData (binding) {
     return new Promise((resolve, reject) => {
       const {columnCount, rowCount} = binding;

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -95,14 +95,14 @@ export default class OfficeConnector {
     });
   }
 
-  createSelectionRange(name, sheet, rangeAddress) {
+  createSelectionRange(sheet, rangeAddress) {
     return new Promise((resolve, reject) => {
       if (!this.isExcelApiSupported()) {
         return resolve();
       }
       Excel.run(function(ctx) {
         // Make each namedItem unique to prevent `already exists` errors
-        const namedItem = name + new Date().getTime().toString();
+        const namedItem = 'name' + new Date().getTime().toString();
         const range = ctx.workbook.worksheets
           .getItem(sheet)
           .getRange(rangeAddress);

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -113,18 +113,23 @@ export default class OfficeConnector {
 
   createBinding(name) {
     return new Promise((resolve, reject) => {
-      Office.context.document.bindings.addFromNamedItemAsync(
-        name,
-        Office.BindingType.Matrix,
-        { id: `dw::${name}` },
-        result => {
-          if (result.status === Office.AsyncResultStatus.Failed) {
-            return reject(result.error.message);
-          }
-          resolve(result.value);
-        }
-      );
-    });
+      // Create binding after Excel sync to have access to newly added nameditem
+      Excel.run((ctx) => {
+        return ctx.sync().then(() => {
+          Office.context.document.bindings.addFromNamedItemAsync(
+            name,
+            Office.BindingType.Matrix,
+            { id: `dw::${name}` },
+            result => {
+              if (result.status === Office.AsyncResultStatus.Failed) {
+                return reject(result.error.message);
+              }
+              resolve(result.value);
+            }
+          );
+        }).catch(reject);
+      });
+    })
   }
 
   removeBinding (binding) {

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -101,23 +101,25 @@ export default class OfficeConnector {
         return resolve();
       }
       Excel.run(function(ctx) {
+        // Make each namedItem unique to prevent `already exists` errors
+        const namedItem = name + new Date().getTime().toString();
         const range = ctx.workbook.worksheets
           .getItem(sheet)
           .getRange(rangeAddress);
         const namedItemCollection = ctx.workbook.names;
-        namedItemCollection.add(name, range, 'Range as a name');
-        return ctx.sync().then(resolve());
+        namedItemCollection.add(namedItem, range, 'Range as a name');
+        return ctx.sync().then(resolve(namedItem));
       });
     });
   }
 
-  createBinding(name) {
+  createBinding(name, namedItem) {
     return new Promise((resolve, reject) => {
       // Create binding after Excel sync to have access to newly added nameditem
       Excel.run((ctx) => {
         return ctx.sync().then(() => {
           Office.context.document.bindings.addFromNamedItemAsync(
-            name,
+            namedItem,
             Office.BindingType.Matrix,
             { id: `dw::${name}` },
             result => {

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -95,14 +95,35 @@ export default class OfficeConnector {
     });
   }
 
-  createBinding (name, options) {
+  createSelectionRange(name, sheet, rangeAddress) {
     return new Promise((resolve, reject) => {
-      Office.context.document.bindings.addFromSelectionAsync(Office.BindingType.Matrix, { id: `dw::${name}` }, (result) => {
-        if (result.status === Office.AsyncResultStatus.Failed) {
-          return reject(result.error.message);
-        }
-        resolve(result.value);
+      if (!this.isExcelApiSupported()) {
+        return resolve();
+      }
+      Excel.run(function(ctx) {
+        const range = ctx.workbook.worksheets
+          .getItem(sheet)
+          .getRange(rangeAddress);
+        const namedItemCollection = ctx.workbook.names;
+        namedItemCollection.add(name, range, 'Range as a name');
+        return ctx.sync().then(resolve());
       });
+    });
+  }
+
+  createBinding(name) {
+    return new Promise((resolve, reject) => {
+      Office.context.document.bindings.addFromNamedItemAsync(
+        name,
+        Office.BindingType.Matrix,
+        { id: `dw::${name}` },
+        result => {
+          if (result.status === Office.AsyncResultStatus.Failed) {
+            return reject(result.error.message);
+          }
+          resolve(result.value);
+        }
+      );
     });
   }
 
@@ -172,9 +193,9 @@ export default class OfficeConnector {
         return resolve();
       }
       Excel.run((ctx) => {
-        const range = ctx.workbook.getSelectedRange().load('address');;
+        const range = ctx.workbook.getSelectedRange().load(['columnCount', 'rowCount', 'address']);
         return ctx.sync().then(() => {
-          resolve(range.address);
+          resolve(range);
         });
       });
     });

--- a/src/components/AddDataModal.css
+++ b/src/components/AddDataModal.css
@@ -66,7 +66,7 @@
   display: flex;
   padding: 12px;
   color: #969696;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .select-sheet {

--- a/src/components/AddDataModal.css
+++ b/src/components/AddDataModal.css
@@ -19,3 +19,60 @@
 .add-data-modal {
   top: 50px;
 }
+
+.selection {
+  display: flex;
+  border: 1px solid #a3afbf;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.selection span {
+  margin: 0;
+  padding-left: 6px;
+  display: flex;
+  align-items: center;
+  font-weight: normal;
+}
+
+.selection span::before {
+  content: '';
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 1em;
+  border: 1px solid white;
+  box-shadow: 0 0 0 0.05em grey;
+  margin-right: 0.75em;
+}
+
+.selection input[type=radio] {
+  display: none;
+}
+
+.selection input[type=radio]:checked + span::before {
+  border: 4.5px solid #328df3;
+  background: white;
+  box-shadow: 0 0 0 0.05em grey;
+}
+
+.selection .radio-button {
+  display: flex;
+  padding: 12px;
+  align-items: center;
+}
+
+.selection .selection-info {
+  display: flex;
+  padding: 12px;
+  color: #969696;
+  font-size: 12px;
+}
+
+.select-sheet {
+  background-color: aliceblue;
+}
+
+.full-screen-modal .center-block .selection-form {
+  padding: 0;
+}

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -169,6 +169,31 @@ class AddDataModal extends Component {
     }
   }
 
+  getSelectionText(range) {
+    if (range) {
+      const rowsInSheet = 1048576;
+      const maxColumns = 150;
+
+      // Return sheet number if entire sheet is selected
+      if (range.rowCount ===  rowsInSheet && range.columnCount === maxColumns) {
+        const selection = range.address;
+        const sheet = selection.substring(0, selection.indexOf('!'));
+        return `(${sheet})`;
+      }
+
+      // Return number of rows and columns in selection
+      const rowCount = range.rowCount;
+      const columnCount = range.columnCount;
+      const rowText = rowCount === 1 ? 'Row' : 'Rows';
+      const columnText = columnCount === 1 ? 'Column' : 'Columns';
+
+      return `(${rowCount} ${rowText} x ${columnCount} ${columnText})`;
+    }
+
+    // Range no yet loaded, return placeholder text
+    return '(Rows x Columns)';
+  }
+
   render () {
     const { name, selectSheet } = this.state;
     const { excelApiSupported, options, range } = this.props;
@@ -204,9 +229,7 @@ class AddDataModal extends Component {
                 </label>
                 <div className='selection-info'>
                   {
-                    range ?
-                    `(${range.rowCount} Rows x ${range.columnCount} Columns)` :
-                    '(Rows x Columns)'
+                    this.getSelectionText(range)
                   }
                 </div>
               </div>

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -51,7 +51,7 @@ class AddDataModal extends Component {
     doesFileExist: PropTypes.func.isRequired,
     excelApiSupported: PropTypes.bool,
     options: PropTypes.object,
-    range: PropTypes.string,
+    range: PropTypes.object,
     refreshLinkedDataset: PropTypes.func,
     sync: PropTypes.func,
     updateBinding: PropTypes.func
@@ -64,7 +64,8 @@ class AddDataModal extends Component {
   state = {
     isSubmitting: false,
     name: this.props.options.filename ? getFilenameWithoutExtension(this.props.options.filename) : '',
-    showWarningModal: false
+    showWarningModal: false,
+    selectSheet: false
   }
 
   isFormValid = () => {
@@ -76,19 +77,26 @@ class AddDataModal extends Component {
     return name.match(filenameRegex) && name.length < MAX_FILENAME_LENGTH;
   }
 
-  submitBinding = () => {
+  submitBinding = (sheet, range) => {
     this.closeModal();
     const { close, createBinding, options, refreshLinkedDataset, sync, updateBinding } = this.props;
+
+    const selection = {
+      name: `${this.state.name}.csv`,
+      sheet: sheet,
+      range: this.state.selectSheet ? 'A1:ET10000' : range.address
+    }
+
     if (options.binding) {
-      updateBinding(options.binding, options.filename)
+      updateBinding(options.binding, selection)
         .then(sync)
         .then(refreshLinkedDataset)
         .then(close);
     } else {
-      createBinding(`${this.getFilename(this.state.name)}.csv`).then((binding) => {
+      createBinding(selection).then((binding) => {
         // Binding has been created, but the file does not exist yet, sync the file
         sync(binding).then(refreshLinkedDataset).then(close);
-      });
+      })
     }
   }
 
@@ -100,7 +108,9 @@ class AddDataModal extends Component {
       // Show warning modal
       this.setState({ showWarningModal: true });
     } else {
-      this.submitBinding();
+      const { range } = this.props;
+      const sheet = `Sheet${this.getSheetNumber(range)}`;
+      this.submitBinding(sheet, range);
     }
   }
 
@@ -129,8 +139,29 @@ class AddDataModal extends Component {
     this.props.close();
   }
 
+  getSheetNumber = (range) => {
+    if (range) {
+      const address = range.address;
+      const sheet = address.substring(0, address.indexOf('!'));
+      const sheetNumber = sheet.match(/[0-9]+/);
+      return sheetNumber;
+    }
+
+    return ''
+  }
+
+  changeSelection = (event) => {
+    const { value } = event.target
+
+    if (value === 'selection') {
+      this.setState({ selectSheet: false})
+    } else if (value === 'sheet') {
+      this.setState({ selectSheet: true });
+    }
+  }
+
   render () {
-    const { name } = this.state;
+    const { name, selectSheet } = this.state;
     const { excelApiSupported, options, range } = this.props;
 
     let validState, displayName;
@@ -149,25 +180,44 @@ class AddDataModal extends Component {
         </Row>
         <Row className='center-block'>
           <form onSubmit={this.submit}>
-            {excelApiSupported && <FormGroup>
-              <ControlLabel>Dataset range</ControlLabel>
-              <InputGroup>
-                <FormControl
-                  value={range}
-                  disabled
-                  type='text' />
-              </InputGroup>
+            {excelApiSupported &&
+            <form className='selection-form' onClick={this.changeSelection}>
+              <div className='selection'>
+                <label className='radio-button'>
+                  <input type='radio' name='selection' value='selection' defaultChecked />
+                  <span>Selection</span>
+                </label>
+                <div className='selection-info'>
+                  {
+                    range ?
+                    `(${range.rowCount} Rows x ${range.columnCount} Columns)` :
+                    '(Rows x Columns)'
+                  }
+                </div>
+              </div>
+              <div className='selection'>
+                <label className='radio-button'>
+                  <input type='radio' name='selection' value='sheet' />
+                  <span>Sheet</span>
+                </label>
+                <div className='selection-info'>
+                  {`(Sheet ${this.getSheetNumber(range)})`}
+                </div>
+              </div>
               <HelpBlock>
-                Select the area to bind in the worksheet, it will be reflected here.
+                {
+                  selectSheet ?
+                  'Select the sheet you\'d like to add, it will be refelected here.' :
+                  'Select the area to bind in the worksheet, it will be reflected here.'
+                }
               </HelpBlock>
-            </FormGroup>}
+            </form>}
             {!excelApiSupported && <div>
               <ControlLabel>Dataset range</ControlLabel>
               <HelpBlock>
                 Select the area to bind in the worksheet.
               </HelpBlock>
             </div>}
-
             <FormGroup validationState={validState}>
               <ControlLabel>Name</ControlLabel>
               <InputGroup>
@@ -187,7 +237,7 @@ class AddDataModal extends Component {
               <Button
                 type='submit'
                 disabled={this.state.isSubmitting || validState !== 'success'}
-                bsStyle='primary'>Add selection</Button>
+                bsStyle='primary'>OK</Button>
             </div>
           </form>
         </Row>
@@ -197,7 +247,7 @@ class AddDataModal extends Component {
           successHandler={this.submitBinding}
           analyticsLocation='exceladdin.add_data'>
           <div><strong>"{displayName}.csv" already exists on data.world.  Do you want to replace it?</strong></div>
-          <div>Replacing it will overwrite the file on data.world with the contents from {excelApiSupported ? range : 'the selected cell range'}</div>
+          <div>Replacing it will overwrite the file on data.world with the contents from {excelApiSupported ? range ? range.address : '' : 'the selected cell range'}</div>
         </WarningModal>
       </Grid>);
   }

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -44,6 +44,23 @@ const getFilenameWithoutExtension = function (filename) {
   return dotPos > -1 ? filename.slice(0, dotPos) : filename;
 }
 
+const selectSheetState = function (options) {
+  const binding = options.binding;
+  // If editing a binding set the state from the binding
+  if (binding) {
+    const maxRows = 1048576;
+    const maxColumns = 150;
+
+    // If it's a sheet binding set to true
+    if (binding.rowCount === maxRows && binding.columnCount === maxColumns) {
+      return true;
+    }
+  }
+
+  // False when creating a new binding or editing a selection binding
+  return false;
+}
+
 class AddDataModal extends Component {
   static propTypes = {
     close: PropTypes.func,
@@ -65,7 +82,7 @@ class AddDataModal extends Component {
     isSubmitting: false,
     name: this.props.options.filename ? getFilenameWithoutExtension(this.props.options.filename) : '',
     showWarningModal: false,
-    selectSheet: false
+    selectSheet: selectSheetState(this.props.options)
   }
 
   isFormValid = () => {
@@ -211,10 +228,16 @@ class AddDataModal extends Component {
         <Row className='center-block'>
           <form onSubmit={this.submit}>
             {excelApiSupported &&
-            <form className='selection-form' onClick={this.changeSelection}>
+            <div className='selection-form' onClick={this.changeSelection}>
               <div className='selection'>
                 <label className='radio-button'>
-                  <input type='radio' name='selection' value='selection' defaultChecked />
+                  <input
+                    type='radio'
+                    name='selection'
+                    value='selection'
+                    checked={!this.state.selectSheet}
+                    readOnly
+                  />
                   <span>Selection</span>
                 </label>
                 <div className='selection-info'>
@@ -223,7 +246,13 @@ class AddDataModal extends Component {
               </div>
               <div className='selection'>
                 <label className='radio-button'>
-                  <input type='radio' name='selection' value='sheet' />
+                  <input
+                    type='radio'
+                    name='selection'
+                    value='sheet'
+                    checked={this.state.selectSheet}
+                    readOnly
+                  />
                   <span>Sheet</span>
                 </label>
                 <div className='selection-info'>
@@ -237,7 +266,7 @@ class AddDataModal extends Component {
                   'Select the area to bind in the worksheet, it will be reflected here.'
                 }
               </HelpBlock>
-            </form>}
+            </div>}
             {!excelApiSupported && <div>
               <ControlLabel>Dataset range</ControlLabel>
               <HelpBlock>

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -80,12 +80,13 @@ class AddDataModal extends Component {
   submitBinding = (sheet, range) => {
     this.closeModal();
     const { close, createBinding, options, refreshLinkedDataset, sync, updateBinding } = this.props;
+    const allRows = 1048576;
 
     const selection = {
       name: `${this.state.name}.csv`,
       sheet: sheet,
-      range: this.state.selectSheet ? 'A1:ET10000' : range.address
-    }
+      range: this.state.selectSheet ? `A1:ET${allRows}` : range.address
+    };
 
     if (options.binding) {
       updateBinding(options.binding, selection)

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -171,16 +171,6 @@ class AddDataModal extends Component {
 
   getSelectionText(range) {
     if (range) {
-      const rowsInSheet = 1048576;
-      const maxColumns = 150;
-
-      // Return sheet number if entire sheet is selected
-      if (range.rowCount ===  rowsInSheet && range.columnCount === maxColumns) {
-        const selection = range.address;
-        const sheet = selection.substring(0, selection.indexOf('!'));
-        return `(${sheet})`;
-      }
-
       // Return number of rows and columns in selection
       const rowCount = range.rowCount;
       const columnCount = range.columnCount;
@@ -228,9 +218,7 @@ class AddDataModal extends Component {
                   <span>Selection</span>
                 </label>
                 <div className='selection-info'>
-                  {
-                    this.getSelectionText(range)
-                  }
+                  { this.getSelectionText(range) }
                 </div>
               </div>
               <div className='selection'>

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -165,11 +165,17 @@ class AddDataModal extends Component {
     const { name, selectSheet } = this.state;
     const { excelApiSupported, options, range } = this.props;
 
-    let validState, displayName;
+    let validState, displayName, selection;
 
     if (name) {
       validState = this.isFormValid() ? 'success' : 'warning'
       displayName = this.getFilename();
+    }
+
+    if (selectSheet) {
+      selection = range ? `Sheet${this.getSheetNumber(range)}` : '';
+    } else {
+      selection = range ? range.address : '';
     }
 
     return (
@@ -248,7 +254,7 @@ class AddDataModal extends Component {
           successHandler={this.submitBinding}
           analyticsLocation='exceladdin.add_data'>
           <div><strong>"{displayName}.csv" already exists on data.world.  Do you want to replace it?</strong></div>
-          <div>Replacing it will overwrite the file on data.world with the contents from {excelApiSupported ? range ? range.address : '' : 'the selected cell range'}</div>
+          <div>Replacing it will overwrite the file on data.world with the contents from {excelApiSupported ? selection : 'the selected cell range'}</div>
         </WarningModal>
       </Grid>);
   }

--- a/src/components/AddDataModal.js
+++ b/src/components/AddDataModal.js
@@ -77,15 +77,25 @@ class AddDataModal extends Component {
     return name.match(filenameRegex) && name.length < MAX_FILENAME_LENGTH;
   }
 
-  submitBinding = (sheet, range) => {
+  submitBinding = () => {
     this.closeModal();
-    const { close, createBinding, options, refreshLinkedDataset, sync, updateBinding } = this.props;
-    const allRows = 1048576;
+    const {
+      close,
+      createBinding,
+      options,
+      refreshLinkedDataset,
+      sync,
+      updateBinding,
+      range
+    } = this.props;
+    const { name, selectSheet } = this.state;
 
+    const sheet = `Sheet${this.getSheetNumber(range)}`;
+    const allRows = 1048576;
     const selection = {
-      name: `${this.state.name}.csv`,
-      sheet: sheet,
-      range: this.state.selectSheet ? `A1:ET${allRows}` : range.address
+      name: `${name}.csv`,
+      sheet,
+      range: selectSheet ? `A1:ET${allRows}` : range.address
     };
 
     if (options.binding) {
@@ -109,9 +119,7 @@ class AddDataModal extends Component {
       // Show warning modal
       this.setState({ showWarningModal: true });
     } else {
-      const { range } = this.props;
-      const sheet = `Sheet${this.getSheetNumber(range)}`;
-      this.submitBinding(sheet, range);
+      this.submitBinding();
     }
   }
 

--- a/src/components/BindingListItem.js
+++ b/src/components/BindingListItem.js
@@ -62,6 +62,24 @@ class BindingsListItem extends Component {
     this.props.removeBinding(this.props.binding);
   }
 
+  showAddress = (binding) => {
+    const range = binding.rangeAddress;
+    if (range) {
+      const maxRows = 1048576;
+      const maxColumns = 150;
+
+      // If it's a sheet binding just show the sheet number
+      if (binding.rowCount === maxRows && binding.columnCount === maxColumns) {
+        return range.substring(0, range.indexOf('!'))
+      } else {
+        return range;
+      }
+    } else {
+      // Still loading
+      return ''
+    }
+  }
+
   render () {
     const { file, binding, syncing, syncStatus } = this.props;
 
@@ -81,7 +99,7 @@ class BindingsListItem extends Component {
           <div className='title'>{file.name}</div>
           {!hasPendingChanges &&
             <div className='info'>
-              {binding && <a onClick={this.onEditClick}>{binding.rangeAddress && `${binding.rangeAddress}`} <Glyphicon glyph='pencil' /> · </a>}
+              {binding && <a onClick={this.onEditClick}>{this.showAddress(binding)} <Glyphicon glyph='pencil' /> · </a>}
               Updated <FormattedDate value={file.updated} year='numeric' month='short' day='2-digit' />
             </div>}
           {hasPendingChanges && <div className='info'>{syncStatus.changes} pending changes</div>}

--- a/src/tests/components/AddDataModal.spec.js
+++ b/src/tests/components/AddDataModal.spec.js
@@ -27,14 +27,33 @@ it('renders modal', () => {
 });
 
 it('renders modal - with range', () => {
-  expect(renderer.create(<AddDataModal range='Sheet1!A2:B5' excelApiSupported />).toJSON()).toMatchSnapshot()
+  expect(renderer.create(
+    <AddDataModal
+      range={{
+        rowCount: 4,
+        columnCount: 2,
+        address: 'Sheet1!A2:B5'
+      }}
+      excelApiSupported
+    />
+  ).toJSON()).toMatchSnapshot()
 });
 
 it('renders modal - with options', () => {
   const options = {
     filename: 'test1.csv'
   };
-  expect(renderer.create(<AddDataModal range='Sheet1!A2:B5' options={options} excelApiSupported />).toJSON()).toMatchSnapshot()
+  expect(renderer.create(
+    <AddDataModal
+      range={{
+        rowCount: 4,
+        columnCount: 2,
+        address: 'Sheet1!A2:B5'
+      }}
+      options={options}
+      excelApiSupported
+    />
+  ).toJSON()).toMatchSnapshot()
 });
 
 it ('removes trailing .csv from filenames', () => {

--- a/src/tests/components/__snapshots__/AddDataModal.spec.js.snap
+++ b/src/tests/components/__snapshots__/AddDataModal.spec.js.snap
@@ -36,7 +36,7 @@ exports[`renders modal - with options 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <form
+      <div
         className="selection-form"
         onClick={[Function]}
       >
@@ -47,8 +47,9 @@ exports[`renders modal - with options 1`] = `
             className="radio-button"
           >
             <input
-              defaultChecked={true}
+              checked={true}
               name="selection"
+              readOnly={true}
               type="radio"
               value="selection"
             />
@@ -69,7 +70,9 @@ exports[`renders modal - with options 1`] = `
             className="radio-button"
           >
             <input
+              checked={false}
               name="selection"
+              readOnly={true}
               type="radio"
               value="sheet"
             />
@@ -88,7 +91,7 @@ exports[`renders modal - with options 1`] = `
         >
           Select the area to bind in the worksheet, it will be reflected here.
         </span>
-      </form>
+      </div>
       <div
         className="form-group has-success"
       >
@@ -188,7 +191,7 @@ exports[`renders modal - with range 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <form
+      <div
         className="selection-form"
         onClick={[Function]}
       >
@@ -199,8 +202,9 @@ exports[`renders modal - with range 1`] = `
             className="radio-button"
           >
             <input
-              defaultChecked={true}
+              checked={true}
               name="selection"
+              readOnly={true}
               type="radio"
               value="selection"
             />
@@ -221,7 +225,9 @@ exports[`renders modal - with range 1`] = `
             className="radio-button"
           >
             <input
+              checked={false}
               name="selection"
+              readOnly={true}
               type="radio"
               value="sheet"
             />
@@ -240,7 +246,7 @@ exports[`renders modal - with range 1`] = `
         >
           Select the area to bind in the worksheet, it will be reflected here.
         </span>
-      </form>
+      </div>
       <div
         className="form-group"
       >

--- a/src/tests/components/__snapshots__/AddDataModal.spec.js.snap
+++ b/src/tests/components/__snapshots__/AddDataModal.spec.js.snap
@@ -36,32 +36,59 @@ exports[`renders modal - with options 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <div
-        className="form-group"
+      <form
+        className="selection-form"
+        onClick={[Function]}
       >
-        <label
-          className="control-label"
-          htmlFor={undefined}
+        <div
+          className="selection"
         >
-          Dataset range
-        </label>
-        <span
-          className="input-group"
+          <label
+            className="radio-button"
+          >
+            <input
+              defaultChecked={true}
+              name="selection"
+              type="radio"
+              value="selection"
+            />
+            <span>
+              Selection
+            </span>
+          </label>
+          <div
+            className="selection-info"
+          >
+            (4 Rows x 2 Columns)
+          </div>
+        </div>
+        <div
+          className="selection"
         >
-          <input
-            className="form-control"
-            disabled={true}
-            id={undefined}
-            type="text"
-            value="Sheet1!A2:B5"
-          />
-        </span>
+          <label
+            className="radio-button"
+          >
+            <input
+              name="selection"
+              type="radio"
+              value="sheet"
+            />
+            <span>
+              Sheet
+            </span>
+          </label>
+          <div
+            className="selection-info"
+          >
+            (Sheet 1)
+          </div>
+        </div>
         <span
           className="help-block"
         >
           Select the area to bind in the worksheet, it will be reflected here.
         </span>
-      </div>
+      </form>
       <div
         className="form-group has-success"
       >
@@ -114,7 +141,7 @@ exports[`renders modal - with options 1`] = `
           disabled={false}
           type="submit"
         >
-          Add selection
+          OK
         </button>
       </div>
     </form>
@@ -161,32 +188,59 @@ exports[`renders modal - with range 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <div
-        className="form-group"
+      <form
+        className="selection-form"
+        onClick={[Function]}
       >
-        <label
-          className="control-label"
-          htmlFor={undefined}
+        <div
+          className="selection"
         >
-          Dataset range
-        </label>
-        <span
-          className="input-group"
+          <label
+            className="radio-button"
+          >
+            <input
+              defaultChecked={true}
+              name="selection"
+              type="radio"
+              value="selection"
+            />
+            <span>
+              Selection
+            </span>
+          </label>
+          <div
+            className="selection-info"
+          >
+            (4 Rows x 2 Columns)
+          </div>
+        </div>
+        <div
+          className="selection"
         >
-          <input
-            className="form-control"
-            disabled={true}
-            id={undefined}
-            type="text"
-            value="Sheet1!A2:B5"
-          />
-        </span>
+          <label
+            className="radio-button"
+          >
+            <input
+              name="selection"
+              type="radio"
+              value="sheet"
+            />
+            <span>
+              Sheet
+            </span>
+          </label>
+          <div
+            className="selection-info"
+          >
+            (Sheet 1)
+          </div>
+        </div>
         <span
           className="help-block"
         >
           Select the area to bind in the worksheet, it will be reflected here.
         </span>
-      </div>
+      </form>
       <div
         className="form-group"
       >
@@ -238,7 +292,7 @@ exports[`renders modal - with range 1`] = `
           disabled={true}
           type="submit"
         >
-          Add selection
+          OK
         </button>
       </div>
     </form>
@@ -349,7 +403,7 @@ exports[`renders modal 1`] = `
           disabled={true}
           type="submit"
         >
-          Add selection
+          OK
         </button>
       </div>
     </form>


### PR DESCRIPTION
**What's New**

Upon clicking on `Add File` the user will now be greeted by two options:

1. Selection (the default) -> Binds the currently selected range.
2. Sheet -> Binds the worksheet's first 150 columns (A to ET) and 10000 rows (can be changed, the worksheet has over 10 million rows).

**Update to Logic**

The create binding function now accepts as its argument an object containing:

1. The file name entered by the user, this also serves as the named item's name.
2. The sheet where the binding is being made.
3. The range, will be the user's selection if `Selection` was selected and `A1:ET10000` if `Sheet` was selected.

Create binding first creates a [nameditem](https://dev.office.com/reference/add-ins/excel/nameditemcollection) using the passed in arguments. A binding is then created from the nameditem using the [addFromNamedItemAsync](https://dev.office.com/reference/add-ins/shared/bindings.addfromnameditemasync) function