### PR TITLE
[#52] Refresh bindings before sync

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,6 +60,7 @@ class App extends Component {
     this.linkNewDataset = this.linkNewDataset.bind(this);
     this.refreshLinkedDataset = this.refreshLinkedDataset.bind(this);
     this.updateBinding = this.updateBinding.bind(this);
+    this.sync = this.sync.bind(this);
 
     this.parsedQueryString = queryString.parse(window.location.search);
 
@@ -374,14 +375,26 @@ class App extends Component {
     return result;
   }
 
+  refreshBindings() {
+    return new Promise((resolve, reject) => {
+      this.office.getBindings().then((bindings) => {
+        resolve(bindings);
+      })
+      .catch((error) => {
+        reject(error);
+      })
+    })
+  }
+
   /**
    * Saves bindings to their associated files on data.world.  If a binding
    * is provided, then only that binding is saved to data.world.
    */
-  sync = (binding) => {
+  async sync(binding) {
     this.setState({syncing: true});
+    const syncedBindings = await this.refreshBindings();
     return new Promise((resolve, reject) => {
-      const bindings = binding ? [binding] : this.state.bindings;
+      const bindings = binding ? [binding] : syncedBindings;
       const promises = [];
       bindings.forEach((binding) => {
         const promise = new Promise((resolve, reject) => {
@@ -411,7 +424,7 @@ class App extends Component {
       });
 
       Promise.all(promises).then(() => {
-        this.setState({syncing: false});
+        this.setState({syncing: false, bindings: syncedBindings});
         resolve();
       }).catch((error) => {
         this.setState({error});


### PR DESCRIPTION
**Source of bug**
Deleting a a column or row also deletes it from a binding so if a binding is to columns A, B and C; deleting column C will also update the binding to be to A and B.

When extracting data for syncing we use the number of rows and columns contained in the binding stored in state which does not get updated when a column or row is deleted. https://github.com/datadotworld/excel-add-in/blob/9615c9203eabad6e4a60d2f7a800f1289fce8ee4/src/OfficeConnector.js#L242

The function therefore throws an exception because the number of rows and columns passed in the options do not correspond to those in Excel's binding.
https://github.com/datadotworld/excel-add-in/blob/9615c9203eabad6e4a60d2f7a800f1289fce8ee4/src/OfficeConnector.js#L292

**Fix**

Refresh the bindings with Excel before syncing.