### PR TITLE
Drop support for Excel 2013

### DIFF
--- a/excel-add-in.xml
+++ b/excel-add-in.xml
@@ -22,6 +22,11 @@
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <Requirements>
+      <Sets DefaultMinVersion="1.4">
+        <Set Name="ExcelApi" MinVersion="1.4"/>
+      </Sets>
+    </Requirements>
     <Hosts>
       <Host xsi:type="Workbook">
         <DesktopFormFactor>

--- a/excel-add-in_local.xml
+++ b/excel-add-in_local.xml
@@ -23,6 +23,11 @@
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <Requirements>
+      <Sets DefaultMinVersion="1.4">
+        <Set Name="ExcelApi" MinVersion="1.4"/>
+      </Sets>
+    </Requirements>
     <Hosts>
       <Host xsi:type="Workbook">
         <!-- Form factor. Currently only DesktopFormFactor is supported. -->


### PR DESCRIPTION
With version 1.1.0.0 we are introducing 2 new add-in commands; Upload
Insights and Import data. Since Excel 2013 does not support add-in
commands users on this platform would not be able to make use of these
new features.

Ref:
https://docs.microsoft.com/en-us/office/dev/add-ins/develop/create-addin-commands#step-2-create-a-task-pane-add-in

The choice to restrict it to ExcelApi 1.4 and above is informed by our
use of namedItemCollectionObject.add which is required to allow for
sheet bindings. This function was introduced in version 1.4 of the
ExcelApi.

Ref:
https://dev.office.com/reference/add-ins/excel/nameditemcollection