### PR TITLE
Fix failing manifest validation

### DIFF
--- a/excel-add-in.xml
+++ b/excel-add-in.xml
@@ -17,16 +17,16 @@
   <Hosts>
     <Host Name="Workbook" />
   </Hosts>
+  <Requirements>
+    <Sets DefaultMinVersion="1.4">
+      <Set Name="ExcelApi" MinVersion="1.4"/>
+    </Sets>
+  </Requirements>
   <DefaultSettings>
     <SourceLocation DefaultValue="https://excel.data.world/?v=1.1.0.0" />
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
-    <Requirements>
-      <Sets DefaultMinVersion="1.4">
-        <Set Name="ExcelApi" MinVersion="1.4"/>
-      </Sets>
-    </Requirements>
     <Hosts>
       <Host xsi:type="Workbook">
         <DesktopFormFactor>

--- a/excel-add-in_local.xml
+++ b/excel-add-in_local.xml
@@ -18,16 +18,16 @@
   <Hosts>
     <Host Name="Workbook" />
   </Hosts>
+  <Requirements>
+    <Sets DefaultMinVersion="1.4">
+      <Set Name="ExcelApi" MinVersion="1.4"/>
+    </Sets>
+  </Requirements>
   <DefaultSettings>
     <SourceLocation DefaultValue="https://localhost:3000/?v=1.1.0.0" />
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
-    <Requirements>
-      <Sets DefaultMinVersion="1.4">
-        <Set Name="ExcelApi" MinVersion="1.4"/>
-      </Sets>
-    </Requirements>
     <Hosts>
       <Host xsi:type="Workbook">
         <!-- Form factor. Currently only DesktopFormFactor is supported. -->


### PR DESCRIPTION
The `Requirments` tag has to appear after the `Hosts` as a child of
`OfficeApp`