### PR TITLE
Add a view for when the add-in is loaded outside of Office

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import LoadingAnimation from './components/LoadingAnimation';
 import LoginHeader from './components/LoginHeader';
 import Insights from './components/Insights';
 import ImportData from './components/ImportData';
+import NotOfficeView from './components/NotOfficeView';
 
 import OfficeConnector from './OfficeConnector';
 import DataDotWorldApi from './DataDotWorldApi';
@@ -128,6 +129,7 @@ class App extends Component {
     }
 
     this.initializeOffice();
+    this.handleNoOfficeTimeout();
   }
 
   async initializeOffice() {
@@ -153,13 +155,23 @@ class App extends Component {
     }
   }
 
+  handleNoOfficeTimeout = () => {
+    setTimeout(() => {
+      if (!this.state.officeInitialized) {
+        this.setState({
+          outsideOffice: true
+        });
+      }
+    }, 2000);
+  }
+
   async initializeDatasets() {
     try {
       const settings = this.office.getSettings();
       let syncStatus = settings.syncStatus;
       let dataset = settings.dataset;
       if (!this.state.loggedIn) {
-        return this.setState({ officeInitialized: true });
+        return this.setState({ officeInitialized: true, outsideOffice: false });
       }
       if (! dataset && this.state.loggedIn) {
         this.getDatasets();
@@ -187,6 +199,7 @@ class App extends Component {
         syncStatus,
         excelApiSupported: this.office.isExcelApiSupported(),
         officeInitialized: true,
+        outsideOffice: false,
         csvMode: this.office.isCSV()
       });
 
@@ -689,7 +702,8 @@ class App extends Component {
       page,
       charts,
       projects,
-      version
+      version,
+      outsideOffice
     } = this.state;
 
     let errorMessage = error;
@@ -707,6 +721,10 @@ class App extends Component {
     const renderDatasetsView = !showStartPage && !dataset && !showCreateDataset && !insights && !importData;
     const renderInsights = !showStartPage && insights;
     const renderImportData = !showStartPage && importData;
+
+    if (outsideOffice) {
+      return (<NotOfficeView />);
+    }
 
     return (
       <div>

--- a/src/components/NotOfficeView.css
+++ b/src/components/NotOfficeView.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+
+ .notOfficeView {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  text-align: center;
+}

--- a/src/components/NotOfficeView.js
+++ b/src/components/NotOfficeView.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+
+import React, { Component } from 'react'
+import {Col, Grid} from 'react-bootstrap'
+import './NotOfficeView.css'
+import analytics from '../analytics'
+
+import sparkle from '../static/img/new-sparkle-logo.png'
+
+class NotOfficeView extends Component {
+
+  supportLinkClick = () => {
+    analytics.track('exceladdin.not_office_view.support.click');
+  }
+
+  installLinkClick = () => {
+    analytics.track('exceladdin.not_office_view.install.click');
+  }
+
+  render () {
+    return (
+      <Grid className='notOfficeView'>
+        <Col md={6} mdOffset={3} xs={10} xsOffset={1}>
+          <img src={sparkle} alt='data.world sparkle logo'/>
+          <h2>
+          Welcome to data.world's Excel add-in.
+          </h2>
+          <p>Install the Excel add-in from the Microsoft <a 
+            href='https://appsource.microsoft.com/en-us/product/office/WA104381270?src=office&tab=Overview'
+            target='_blank'
+            onClick={this.installLinkClick}
+            rel='noopener noreferrer'
+          >AppSource</a></p>
+          <a
+            href='https://data.world/integrations/excel'
+            target='_blank'
+            onClick={this.supportLinkClick}
+            rel="noopener noreferrer"
+          >
+            Learn more about the data.world add-in
+          </a>
+        </Col>
+      </Grid>
+    )
+  }
+}
+
+export default NotOfficeView;

--- a/src/components/NotOfficeView.js
+++ b/src/components/NotOfficeView.js
@@ -40,9 +40,9 @@ class NotOfficeView extends Component {
         <Col md={6} mdOffset={3} xs={10} xsOffset={1}>
           <img src={sparkle} alt='data.world sparkle logo'/>
           <h2>
-          Welcome to data.world's Excel add-in.
+          data.world + Excel
           </h2>
-          <p>Install the Excel add-in from the Microsoft <a 
+          <p>Install the data.world add-in for Excel from Microsoft <a
             href='https://appsource.microsoft.com/en-us/product/office/WA104381270?src=office&tab=Overview'
             target='_blank'
             onClick={this.installLinkClick}
@@ -54,7 +54,7 @@ class NotOfficeView extends Component {
             onClick={this.supportLinkClick}
             rel="noopener noreferrer"
           >
-            Learn more about the data.world add-in
+            Learn more
           </a>
         </Col>
       </Grid>


### PR DESCRIPTION
The Office JavaScript API does not currently offer the ability to detect when it has been loaded outside of an Office context.  Use a 2 second timeout as a basis for detecting this.  If initialization takes longer than 2 seconds, it will toggle back to displaying the correct view.

![screen shot 2018-03-30 at 1 29 35 pm](https://user-images.githubusercontent.com/1616066/38198646-4ce21b7e-3653-11e8-897d-de6e2b4efa32.png)
