### PR TITLE
In Excel add-on, default new datasets to private

### DIFF
--- a/src/components/CreateDatasetModal.js
+++ b/src/components/CreateDatasetModal.js
@@ -51,7 +51,7 @@ class CreateDatasetModal extends Component {
   state = {
     isSubmitting: false,
     title: '',
-    visibility: 'OPEN',
+    visibility: 'PRIVATE',
     error: null
   }
 
@@ -137,6 +137,15 @@ class CreateDatasetModal extends Component {
               </HelpBlock>  
             </FormGroup>
             <FormGroup>
+            <Radio
+                name='privacy'
+                onChange={this.visibilityChanged}
+                checked={visibility === 'PRIVATE'}
+                className={visibility === 'PRIVATE' ? 'checked' : ''}
+                value='PRIVATE' >
+                <div className='radio-label'>Private <Glyphicon glyph='lock' /></div>
+                <div className='radio-option-description'>Will only be shared with others you invite.</div>
+              </Radio>
               <Radio
                 name='privacy'
                 onChange={this.visibilityChanged}
@@ -145,15 +154,6 @@ class CreateDatasetModal extends Component {
                 value='OPEN'>
                 <div className='radio-label'>Open</div>
                 <div className='radio-option-description'>Publicly available data that anyone can view, query, or download.</div>
-              </Radio>
-              <Radio
-                name='privacy'
-                onChange={this.visibilityChanged}
-                checked={visibility === 'PRIVATE'}
-                className={visibility === 'PRIVATE' ? 'checked' : ''}
-                value='PRIVATE' >
-                <div className='radio-label'>Private <Glyphicon glyph='lock' /></div>
-                <div className='radio-option-description'>Will only be shared with others you invite. Use for personal or sensitive information.</div>
               </Radio>
             </FormGroup>
             <div className='button-group'>

--- a/src/tests/components/__snapshots__/CreateDatasetModal.spec.js.snap
+++ b/src/tests/components/__snapshots__/CreateDatasetModal.spec.js.snap
@@ -89,17 +89,20 @@ exports[`renders modal 1`] = `
               name="privacy"
               onChange={[Function]}
               type="radio"
-              value="OPEN"
+              value="PRIVATE"
             />
             <div
               className="radio-label"
             >
-              Open
+              Private 
+              <span
+                className="glyphicon glyphicon-lock"
+              />
             </div>
             <div
               className="radio-option-description"
             >
-              Publicly available data that anyone can view, query, or download.
+              Will only be shared with others you invite.
             </div>
           </label>
         </div>
@@ -116,20 +119,17 @@ exports[`renders modal 1`] = `
               name="privacy"
               onChange={[Function]}
               type="radio"
-              value="PRIVATE"
+              value="OPEN"
             />
             <div
               className="radio-label"
             >
-              Private 
-              <span
-                className="glyphicon glyphicon-lock"
-              />
+              Open
             </div>
             <div
               className="radio-option-description"
             >
-              Will only be shared with others you invite. Use for personal or sensitive information.
+              Publicly available data that anyone can view, query, or download.
             </div>
           </label>
         </div>


### PR DESCRIPTION
Now: 
<img width="372" alt="screen shot 2018-06-21 at 4 41 15 pm" src="https://user-images.githubusercontent.com/38888607/41746977-f3ea600e-7571-11e8-9078-6545e5d0f244.png">


Excel - does not default new datasets to private, inconsistent with web UI