### PR TITLE
Run bindings migration once

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -196,8 +196,8 @@ class App extends Component {
   async initializeDatasets() {
     try {
       const settings = this.office.getSettings();
-      let syncStatus = settings.syncStatus;
-      let dataset = settings.dataset;
+      let { syncStatus, dataset, migratedBindings } = settings
+
       if (!this.state.loggedIn) {
         return this.setState({ officeInitialized: true, outsideOffice: false });
       }
@@ -221,15 +221,24 @@ class App extends Component {
         }
       });
 
-      if (dataset && bindings.length > 0) {
-        const datasetFiles = dataset.files.map(entry => entry.name)
+      if (!migratedBindings && dataset && bindings.length > 0) {
+        const datasetFiles = dataset.files.map(entry => entry.name);
         bindings.forEach((binding) => {
-          const sheetId = getSheetName(binding)
-          const filename = binding.id.replace('dw::', '')
+          const sheetId = getSheetName(binding);
+          const filename = binding.id.replace('dw::', '');
           if (datasetFiles.includes(filename)) {
-            this.pushToLocalStorage(binding.id, `https://data.world/${dataset.owner}/${dataset.id}`, filename, binding.rangeAddress, sheetId, dataset.updated)
+            this.pushToLocalStorage(
+              binding.id,
+              `https://data.world/${dataset.owner}/${dataset.id}`,
+              filename,
+              binding.rangeAddress,
+              sheetId,
+              dataset.updated
+            );
           }
-        })
+        });
+
+        this.office.setMigratedBindings(true);
       }
 
       this.setState({

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -175,7 +175,8 @@ export default class OfficeConnector {
   getSettings () {
     return {
       dataset: Office.context.document.settings.get('dataset'),
-      syncStatus: Office.context.document.settings.get('syncStatus')
+      syncStatus: Office.context.document.settings.get('syncStatus'),
+      migratedBindings: Office.context.document.settings.get('migratedBindings'),
     };
   }
 
@@ -197,6 +198,11 @@ export default class OfficeConnector {
 
   setDataset (dataset) {
     Office.context.document.settings.set('dataset', dataset);
+    return this.saveSettings();
+  }
+
+  setMigratedBindings (migratedBindings) {
+    Office.context.document.settings.set('migratedBindings', migratedBindings);
     return this.saveSettings();
   }
 

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -176,7 +176,7 @@ export default class OfficeConnector {
     return {
       dataset: Office.context.document.settings.get('dataset'),
       syncStatus: Office.context.document.settings.get('syncStatus'),
-      migratedBindings: Office.context.document.settings.get('migratedBindings'),
+      nextMigrationIndex: Office.context.document.settings.get('nextMigrationIndex'),
     };
   }
 
@@ -201,8 +201,8 @@ export default class OfficeConnector {
     return this.saveSettings();
   }
 
-  setMigratedBindings (migratedBindings) {
-    Office.context.document.settings.set('migratedBindings', migratedBindings);
+  setNextMigrationIndex (idx) {
+    Office.context.document.settings.set('nextMigrationIndex', idx);
     return this.saveSettings();
   }
 

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,0 +1,24 @@
+const migrateBindings = ({
+  dataset,
+  bindings,
+  getSheetName,
+  pushToLocalStorage
+}) => {
+  const datasetFiles = dataset.files.map(entry => entry.name);
+  bindings.forEach((binding) => {
+    const sheetId = getSheetName(binding);
+    const fileName = binding.id.replace("dw::", "");
+    if (datasetFiles.includes(fileName)) {
+      pushToLocalStorage(
+        binding.id,
+        `https://data.world/${dataset.owner}/${dataset.id}`,
+        fileName,
+        binding.rangeAddress,
+        sheetId,
+        dataset.updated
+      );
+    }
+  });
+};
+
+export default [migrateBindings];


### PR DESCRIPTION
Resolves #79 

Problem:

Bindings migration is done every time the app starts up. Recent upload history is derived from these bindings before being saved to local storage.

Since the migration happens on each app launch recent upload history is being copied across browsers.

Solution:

Mark a document's bindings as migrated by setting a key to the document's settings. This ensures migrations are only done once.