### PR TITLE
Remove bottom margin on the error banner

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -206,3 +206,7 @@ body {
 .help-block {
   font-size: 0.6875rem;
 }
+
+.error-alert {
+  margin-bottom: 0 !important;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -809,7 +809,7 @@ class App extends Component {
     }
     return (
       <div>
-        {error && <Alert bsStyle='danger' onDismiss={this.dismissError}>{errorMessage}</Alert>}
+        {error && <Alert className="error-alert" bsStyle='danger' onDismiss={this.dismissError}>{errorMessage}</Alert>}
         {!officeInitialized && !error && <LoadingAnimation />}
         {loggedIn && <LoginHeader user={user} logout={this.logout} page={page} />}
         {showStartPage && <WelcomePage dataset={dataset} page={page} version={version} />}


### PR DESCRIPTION
Before:
<img width="364" alt="screen shot 2018-09-26 at 16 16 48" src="https://user-images.githubusercontent.com/17295379/46083680-9c8eb780-c1aa-11e8-9958-1f5315bf96b0.png">

After:
<img width="369" alt="screen shot 2018-09-26 at 16 39 46" src="https://user-images.githubusercontent.com/17295379/46083800-d3fd6400-c1aa-11e8-907b-db629191e801.png">
