### PR TITLE
Show most up to date sheet name

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -733,6 +733,7 @@ export default class App extends Component {
               user={userId}
               workbook={this.state.workbookId}
               matchedFiles={matchedFiles}
+              getSheetName={this.office.getSheetName}
             />
           )}
 

--- a/src/OfficeConnector.js
+++ b/src/OfficeConnector.js
@@ -275,6 +275,19 @@ export default class OfficeConnector {
     });
   }
 
+  getSheetName(sheetId) {
+    return new Promise((resolve, reject) => {
+      Excel.run(function(ctx) {
+        const worksheet = ctx.workbook.worksheets.getItem(sheetId);
+        worksheet.load('name');
+        return ctx
+          .sync()
+          .then(() => resolve(worksheet.name))
+          .catch(reject);
+      });
+    });
+  }
+
   select(address = '') {
     const addressSections = address.split('!');
     return new Promise((resolve, reject) => {

--- a/src/components/RecentUploads.js
+++ b/src/components/RecentUploads.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 
 import { Button, ControlLabel, Image } from 'react-bootstrap';
-import { getDisplayRange } from '../util';
 import Icon from './icons/Icon';
 import './RecentUploads.css';
 
 class RecentItem extends Component {
   state = {
-    loading: false
+    loading: false,
+    sheetName: ''
   };
 
   sync = async (filename, rangeAddress, dataset, worksheetId) => {
@@ -21,6 +21,12 @@ class RecentItem extends Component {
     }
   };
 
+  componentDidMount() {
+    this.props.getSheetName(this.props.worksheetId).then((sheetName) => {
+      this.setState({ sheetName });
+    });
+  }
+
   render() {
     const { filename, dataset, rangeAddress, worksheetId } = this.props;
 
@@ -28,7 +34,8 @@ class RecentItem extends Component {
 
     const tabular = require('./icons/icon-tabular.svg');
 
-    const rangeToShow = getDisplayRange(rangeAddress);
+    const rangeToShow = `${this.state.sheetName}!${rangeAddress.split('!')[1]}`;
+    const datasetSlug = `=${rangeToShow}`;
     return (
       <div>
         <div className="item recent">
@@ -68,7 +75,7 @@ class RecentItem extends Component {
 
 export default class RecentUploads extends Component {
   render() {
-    const { forceShowUpload, matchedFiles } = this.props;
+    const { forceShowUpload, matchedFiles, getSheetName } = this.props;
 
     let previousDate = '';
     let showDate;
@@ -102,6 +109,7 @@ export default class RecentUploads extends Component {
                 {...file}
                 sync={this.props.sync}
                 setError={this.props.setError}
+                getSheetName={getSheetName}
               />
             </div>
           );

--- a/src/components/RecentUploads.js
+++ b/src/components/RecentUploads.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import { Button, ControlLabel, Image } from 'react-bootstrap';
+import { getDisplayRange } from '../util';
 import Icon from './icons/Icon';
 import './RecentUploads.css';
 
@@ -34,8 +35,7 @@ class RecentItem extends Component {
 
     const tabular = require('./icons/icon-tabular.svg');
 
-    const rangeToShow = `${this.state.sheetName}!${rangeAddress.split('!')[1]}`;
-    const datasetSlug = `=${rangeToShow}`;
+    const rangeToShow = getDisplayRange(rangeAddress, this.state.sheetName);
     return (
       <div>
         <div className="item recent">

--- a/src/util.js
+++ b/src/util.js
@@ -18,11 +18,15 @@
  */
 import { SHEET_RANGE } from './constants';
 
-export function getDisplayRange(rangeAddress) {
+export function getDisplayRange(rangeAddress, sheetName) {
   if (rangeAddress) {
     const [sheet, range] = rangeAddress.split('!');
     if (range === SHEET_RANGE) {
-      return sheet.replace(/'/g, '');
+      return sheetName || sheet.replace(/'/g, '');
+    }
+
+    if (sheetName) {
+      return `${sheetName}!${range}`;
     }
 
     return rangeAddress.replace(/'/g, '');


### PR DESCRIPTION
The user may rename the sheet after an upload.

These changes ensure the most up to date sheet name is displayed when the recent uploads page loads.