### PR TITLE
Link to workspace, table and query

### DIFF
--- a/src/components/RecentImports/RecentItem/index.js
+++ b/src/components/RecentImports/RecentItem/index.js
@@ -20,7 +20,11 @@
 import React, { Component } from 'react';
 import { Image, Tooltip, OverlayTrigger } from 'react-bootstrap';
 
-import { getDestination } from '../../../util';
+import {
+  getDestination,
+  createItemLink,
+  createWorkspaceLink
+} from '../../../util';
 import './RecentItem.css';
 
 const tableIcon = require('../../icons/icon-table.svg');
@@ -59,12 +63,19 @@ export default class RecentItem extends Component {
           <div className="recent-item-file">
             {!isQuery && <Image className="icon-download" src={tableIcon} />}
             {isQuery && <Image className="icon-download" src={queryIcon} />}
-            {table.name}
+            <a
+              className="recent-item-link"
+              href={createItemLink(dataset, table, isQuery)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {table.name}
+            </a>
           </div>
           <div className="recent-item-dataset">
             <a
               className="recent-item-link"
-              href={`https://data.world/${dataset.owner}/${dataset.id}`}
+              href={createWorkspaceLink(dataset)}
               target="_blank"
               rel="noopener noreferrer"
             >{`${dataset.owner}/${dataset.id}`}</a>

--- a/src/tests/util.spec.js
+++ b/src/tests/util.spec.js
@@ -161,7 +161,7 @@ describe('util functions', () => {
       const item = { name: 'data' };
 
       const expected =
-        'https://data.world/owner/dataset/workspace/query?newQueryContent=SELECT%20*%20FROM%20data&&newQueryType=SQL';
+        'https://data.world/owner/dataset/workspace/query?autorunQuery=true&newQueryContent=SELECT%20%2A%20FROM%20data&newQueryType=SQL';
       const actual = createItemLink(dataset, item);
 
       expect(expected).toEqual(actual);

--- a/src/tests/util.spec.js
+++ b/src/tests/util.spec.js
@@ -19,7 +19,9 @@
 import {
   sortByOwnerAndTitle,
   createSubArrays,
-  hasDuplicateName
+  hasDuplicateName,
+  createWorkspaceLink,
+  createItemLink
 } from '../util';
 
 describe('util functions', () => {
@@ -139,6 +141,44 @@ describe('util functions', () => {
       );
 
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('createWorkspaceLink', () => {
+    it('should return a workspace link', () => {
+      const dataset = { owner: 'owner', id: 'dataset' };
+
+      const expected = 'https://data.world/owner/dataset/workspace/';
+      const actual = createWorkspaceLink(dataset);
+
+      expect(expected).toEqual(actual);
+    });
+  });
+
+  describe('createItemLink', () => {
+    it('should return a table link', () => {
+      const dataset = { owner: 'owner', id: 'dataset' };
+      const item = { name: 'data' };
+
+      const expected =
+        'https://data.world/owner/dataset/workspace/query?newQueryContent=SELECT%20*%20FROM%20data&&newQueryType=SQL';
+      const actual = createItemLink(dataset, item);
+
+      expect(expected).toEqual(actual);
+    });
+
+    it('should return a query link', () => {
+      const dataset = { owner: 'owner', id: 'dataset' };
+      const item = {
+        name: 'aQuery',
+        id: '1234-5678'
+      };
+
+      const expected =
+        'https://data.world/owner/dataset/workspace/query?queryid=1234-5678';
+      const actual = createItemLink(dataset, item, true);
+
+      expect(expected).toEqual(actual);
     });
   });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -195,3 +195,25 @@ export function hasDuplicateName({ name, dataset }, array) {
 
   return withSameName > 0;
 }
+
+export function createWorkspaceLink(dataset) {
+  return `https://data.world/${dataset.owner}/${dataset.id}/workspace/`;
+}
+
+export function createItemLink(dataset, item, isQuery) {
+  const base = `https://data.world/${dataset.owner}/${
+    dataset.id
+  }/workspace/query?`;
+
+  if (isQuery) {
+    return `${base}queryid=${item.id}`;
+  }
+
+  const query = `newQueryContent=${encodeURIComponent(
+    `SELECT * FROM ${item.name}`
+  )}`;
+
+  const queryType = 'newQueryType=SQL';
+
+  return `${base}${query}&&${queryType}`;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -18,6 +18,7 @@
  */
 
 import { SHEET_RANGE } from './constants';
+import queryString from 'query-string';
 
 export function getDisplayRange(rangeAddress, sheetName) {
   if (rangeAddress) {
@@ -205,15 +206,17 @@ export function createItemLink(dataset, item, isQuery) {
     dataset.id
   }/workspace/query?`;
 
+  let query;
+
   if (isQuery) {
-    return `${base}queryid=${item.id}`;
+    query = queryString.stringify({ queryid: item.id });
+  } else {
+    query = queryString.stringify({
+      newQueryContent: `SELECT * FROM ${item.name}`,
+      newQueryType: 'SQL',
+      autorunQuery: 'true'
+    });
   }
 
-  const query = `newQueryContent=${encodeURIComponent(
-    `SELECT * FROM ${item.name}`
-  )}`;
-
-  const queryType = 'newQueryType=SQL';
-
-  return `${base}${query}&&${queryType}`;
+  return base + query;
 }


### PR DESCRIPTION
On the recent imports screen:

<img width="359" alt="screen shot 2018-12-06 at 19 20 15" src="https://user-images.githubusercontent.com/17295379/49596719-089c5180-f98c-11e8-8511-1b138b91f352.png">

The table/query name links to:
  * table: the dataset workspace pre-filled with a `SELECT * FROM ${table}` query
  * query: the dataset workspace with the query pre-filled

The dataset (`owner/id`) links to the dataset workspace
