### PR TITLE
Replace `findIndex` function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@
  */
 import React, { Component } from 'react';
 import queryString from 'query-string';
-import { flatten } from 'lodash';
+import { flatten, findIndex } from 'lodash';
 
 import { Alert } from 'react-bootstrap';
 import find from 'array.prototype.find';
@@ -353,7 +353,7 @@ export default class App extends Component {
       date
     };
 
-    const fileIndex = recentUploads.findIndex((upload) => {
+    const fileIndex = findIndex(recentUploads, (upload) => {
       // Same file uploaded to the same dataset
       if (
         upload.filename === filename &&

--- a/src/components/ImportData/index.js
+++ b/src/components/ImportData/index.js
@@ -30,6 +30,7 @@ import {
   MenuItem,
   Modal
 } from 'react-bootstrap';
+import { findIndex } from 'lodash';
 import {
   getDestination,
   getExcelColumn,
@@ -256,7 +257,7 @@ export default class UploadModal extends Component {
       date
     };
 
-    const fileIndex = recentImports.findIndex((recentImport) => {
+    const fileIndex = findIndex(recentImports, (recentImport) => {
       if (
         recentImport.table.name === table.name &&
         recentImport.sheetName === sheetName


### PR DESCRIPTION
Replace ES6's `findIndex` with the lodash equivalent due to incompatibility with IE