### PR TITLE
Ensure user is fetched before running migrations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,7 +116,7 @@ export default class App extends Component {
       await this.getUser();
     }
 
-    this.initializeOffice();
+    await this.initializeOffice();
   }
 
   getSelectionRange = async () => {

--- a/src/App.js
+++ b/src/App.js
@@ -107,17 +107,16 @@ export default class App extends Component {
       loadingSync: false,
       selectSheet: false
     };
+  }
 
+  async componentDidMount() {
+    const { token } = this.state;
     if (token) {
       this.api = new DataDotWorldApi(token);
-      this.getUser().catch((error) => {
-        this.setError(error);
-      });
+      await this.getUser();
     }
 
-    this.initializeOffice().catch((error) => {
-      this.setError(error);
-    });
+    this.initializeOffice();
   }
 
   getSelectionRange = async () => {


### PR DESCRIPTION
Before:

```
    if (token) {
      this.getUser().catch((error) => {
        this.setError(error);
      });
    }

    this.initializeOffice().catch((error) => {
      this.setError(error);
    });
```

Race condition: It was possible for `initilializeOffice` to run (which would in turn run migrations) before `getUser` resolved. This would cause an error when migrations were ran.

After:

```
  async componentDidMount() {
    const { token } = this.state;
    if (token) {
      await this.getUser();
    }

    this.initializeOffice();
  }
```

When a token is present `initializeOffice` can only run after `getUser` resolves