### PR TITLE
SENG-1 | replacing getDataset API with Search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -227,12 +227,12 @@ export default class App extends Component {
     )}`;
   };
 
-  getDatasets = async (onlyShowWritableDatasets) => {
+  getDatasets = async (query, owner) => {
     try {
       this.setState({ loadingDatasets: true });
-      const datasets = await this.api.getDatasets(onlyShowWritableDatasets);
+      const datasets = await this.api.searchDatasetsAndProjects(query, owner);
       this.setState({ loadingDatasets: false });
-      return datasets;
+      return datasets
     } catch (getDatasetsError) {
       this.setState({
         error: getDatasetsError,
@@ -631,7 +631,6 @@ export default class App extends Component {
       forceShowUpload,
       selectSheet,
       errorMessage,
-      onlyShowWritableDatasets,
       recents
     } = this.state;
 
@@ -763,7 +762,7 @@ export default class App extends Component {
             toggleList={this.toggleList}
             toggleShowForm={this.showCreateDataset}
             getItems={this.getDatasets}
-            onlyShowWritableDatasets={onlyShowWritableDatasets}
+            // onlyShowWritableDatasets={onlyShowWritableDatasets}
           />
         )}
 

--- a/src/DataDotWorldApi.js
+++ b/src/DataDotWorldApi.js
@@ -30,6 +30,25 @@ export default class DataDotWorldApi {
     });
   }
 
+  async searchDatasetsAndProjects(query, owner) {
+    const { data } = await this.api.post('/search/resources', {
+      category: ['dataset', 'project'],
+      query: query,
+      owner: [owner]
+    });
+
+    const datasets = data.records.map(record => ({
+      owner: record.owner,
+      id: record.id,
+      title: record.title,
+      created: record.created,
+      updated: record.updated,
+      category: record.category,
+    }));
+
+    return datasets;
+  }
+  
   async getLibraryRecursive(endpoint, partial = [], next) {
     if (next === -1) {
       return partial;

--- a/src/components/ImportData/index.js
+++ b/src/components/ImportData/index.js
@@ -48,6 +48,8 @@ const download = require('../icons/icon-download.svg');
 
 export default class UploadModal extends Component {
   state = {
+    query: '',
+    owner: '',
     itemUrl: '',
     querySelected: false,
     tableSelected: false,
@@ -61,6 +63,19 @@ export default class UploadModal extends Component {
     showWarningModal: false,
     show404Modal: false,
     selectedItem: ''
+  };
+
+  handleQueryChange = (event) => {
+    this.setState({ query: event.target.value });
+  };
+
+  handleOwnerChange = (event) => {
+    this.setState({ owner: event.target.value });
+  };
+
+  handleBrowseClick = () => {
+    const { query, owner } = this.state;
+    this.props.getDatasets(query, owner);
   };
 
   getTables = async (dataset) => {
@@ -362,6 +377,8 @@ export default class UploadModal extends Component {
   render() {
     const { clearRecentItem } = this.props;
     const {
+      query,
+      owner,
       itemUrl,
       querySelected,
       tableSelected,
@@ -399,20 +416,39 @@ export default class UploadModal extends Component {
         {showImportForm && (
           <div>
             <div className="import-header">
-              <ControlLabel className="import-header-text">
-                Import data
-              </ControlLabel>
+              <ControlLabel className="import-header-text">Import data</ControlLabel>
             </div>
             <div className="import-container">
               <div className="import-from">
+                <FormGroup>
+                  <ControlLabel>Search for a Project or Dataset</ControlLabel>
+                  <FormControl
+                    type="text"
+                    placeholder="Enter Project or Dataset name"
+                    value={query}
+                    onChange={this.handleQueryChange}
+                  />
+                </FormGroup>
+                
+                <FormGroup>
+                  <ControlLabel>Organization ID</ControlLabel>
+                  <FormControl
+                    type="text"
+                    placeholder="Enter Organization ID"
+                    value={owner}
+                    onChange={this.handleOwnerChange}
+                  />
+                </FormGroup>
+
                 <SelectItem
-                  itemUrl={this.state.itemUrl}
+                  itemUrl={itemUrl}
                   handleChange={this.handleUrlChange}
                   getItems={this.props.getDatasets}
-                  title="Import from:"
-                  placeholder="Insert Dataset or Project URL"
                   hideCreateNew
+                  query={query}
+                  owner={owner}
                 />
+                
                 <div className="import-radio-container">
                   <div className="import-sub-title">Source:</div>
                   <div className="import-radio-item">

--- a/src/components/ImportData/index.js
+++ b/src/components/ImportData/index.js
@@ -421,10 +421,10 @@ export default class UploadModal extends Component {
             <div className="import-container">
               <div className="import-from">
                 <FormGroup>
-                  <ControlLabel>Search for a Project or Dataset</ControlLabel>
+                  <ControlLabel>Search for a dataset or project</ControlLabel>
                   <FormControl
                     type="text"
-                    placeholder="Enter Project or Dataset name"
+                    placeholder="Enter dataset or project name"
                     value={query}
                     onChange={this.handleQueryChange}
                   />
@@ -434,7 +434,7 @@ export default class UploadModal extends Component {
                   <ControlLabel>Organization ID</ControlLabel>
                   <FormControl
                     type="text"
-                    placeholder="Enter Organization ID"
+                    placeholder="Enter organization ID"
                     value={owner}
                     onChange={this.handleOwnerChange}
                   />

--- a/src/components/SelectItem/LibraryView/LibraryItem/index.js
+++ b/src/components/SelectItem/LibraryView/LibraryItem/index.js
@@ -34,7 +34,7 @@ class LibraryItem extends Component {
   buttonClick = () => {
     if (this.props.buttonHandler) {
       const { item } = this.props;
-      const uri = `https://data.world/${item.owner}/${item.id}`;
+      const uri = `${item.owner}/${item.id}`;
       this.props.buttonHandler(uri);
     }
   };

--- a/src/components/SelectItem/LibraryView/index.js
+++ b/src/components/SelectItem/LibraryView/index.js
@@ -25,19 +25,9 @@ import LoadingAnimation from '../../LoadingAnimation';
 import './LibraryView.css';
 
 export default class LibraryView extends Component {
-  state = {
-    items: [],
-    loading: true
-  };
-
-  componentDidMount() {
-    this.props.getItems().then((items) => {
-      this.setState({ items, loading: false });
-    });
-  }
 
   sortItems = () => {
-    const sortedItems = this.state.items.slice();
+    const sortedItems = this.props.items.slice();
 
     // Sort by updated in descending order
     sortedItems.sort((a, b) => {
@@ -63,19 +53,22 @@ export default class LibraryView extends Component {
       toggleShowForm,
       onSelect,
       close,
-      hideCreateNew
+      hideCreateNew,
+      loading,
+      items
     } = this.props;
-    const { loading, items } = this.state;
 
     const sortedItems = this.sortItems(items);
     const entries = sortedItems.map((item) => {
+      const isProject = item.category === 'project' || isProjects;
+
       return (
         <LibraryItem
           item={item}
           key={`${item.owner}/${item.id}`}
           buttonText="Link"
           buttonHandler={onSelect}
-          isProject={isProjects || item.isProject}
+          isProject={isProject}
         />
       );
     });
@@ -108,20 +101,11 @@ export default class LibraryView extends Component {
             </Row>
           )}
           {!items.length && !loading && (
-            <Row className="center-block no-datasets">
-              <div className="message">
-                {isProjects
-                  ? "You haven't created any projects to upload the insight to."
-                  : "You haven't created any datasets to link data to."}
-              </div>
-              <Button
-                className="bottom-button"
-                bsStyle="primary"
-                onClick={toggleShowForm}
-              >
-                {isProjects ? 'Create a new project' : 'Create a new dataset'}
-              </Button>
-            </Row>
+             <Row className="center-block no-datasets">
+             <div className="message">
+               No results found, please refine your search.
+             </div>
+           </Row>
           )}
         </div>
       </Grid>

--- a/src/components/SelectItem/index.js
+++ b/src/components/SelectItem/index.js
@@ -21,9 +21,7 @@ import React, { Component } from 'react';
 import {
   Button,
   ControlLabel,
-  FormControl,
   FormGroup,
-  InputGroup
 } from 'react-bootstrap';
 
 import LibraryView from './LibraryView';
@@ -32,7 +30,26 @@ import './SelectItem.css';
 
 export default class UploadModal extends Component {
   state = {
-    showLibrary: false
+    showLibrary: false,
+    items: [],
+    loading: true
+  };
+
+  handleBrowseClick = () => {
+    const { getItems, query, owner } = this.props;
+
+    this.setState({ loading: true });
+
+    if (!query || !owner) {
+      this.setState({ loading: false });
+      return;
+    }
+
+    getItems(query, owner).then((items) => {
+      this.setState({ items, loading: false, showLibrary: true });
+    }).catch(() => {
+      this.setState({ loading: false });
+    });
   };
 
   onSelect = (url) => {
@@ -41,43 +58,36 @@ export default class UploadModal extends Component {
   };
 
   render() {
-    const { showLibrary } = this.state;
-    const { title, placeholder, handleChange } = this.props;
+    const { showLibrary, items, loading } = this.state;
+    const { title, query, owner, itemUrl } = this.props;
 
     return (
       <div>
         {!showLibrary && (
           <FormGroup>
+            <Button
+              bsStyle="primary"
+              onClick={this.handleBrowseClick}
+              disabled={!query || !owner}
+            >
+              Search
+            </Button>
+
             <div>
-              <ControlLabel className="select-item-title">{title}</ControlLabel>
-              <InputGroup>
-                <div className="select-item-container">
-                  <FormControl
-                    className="select-item-field"
-                    placeholder={placeholder}
-                    value={this.props.itemUrl}
-                    type="text"
-                    onChange={(event) => {
-                      handleChange(event.target.value);
-                    }}
-                  />
-                  <Button
-                    className="select-item-button"
-                    onClick={() => {
-                      this.setState({ showLibrary: true });
-                    }}
-                  >
-                    Browse
-                  </Button>
-                </div>
-              </InputGroup>
+              <ControlLabel className="select-item-title">{title}</ControlLabel>    
+              {itemUrl && (
+                <FormGroup>
+                  Loaded: <ControlLabel>{itemUrl}</ControlLabel>
+                </FormGroup>
+              )}
             </div>
           </FormGroup>
-        )}
+        )}                  
         {showLibrary && (
           <LibraryView
             close={() => this.setState({ showLibrary: false })}
-            getItems={this.props.getItems}
+            items={items}       
+            loading={loading}
             onSelect={this.onSelect}
             hideCreateNew={this.props.hideCreateNew}
           />

--- a/src/components/SelectItem/index.js
+++ b/src/components/SelectItem/index.js
@@ -22,6 +22,8 @@ import {
   Button,
   ControlLabel,
   FormGroup,
+  InputGroup,
+  FormControl
 } from 'react-bootstrap';
 
 import LibraryView from './LibraryView';
@@ -75,11 +77,22 @@ export default class UploadModal extends Component {
 
             <div>
               <ControlLabel className="select-item-title">{title}</ControlLabel>    
-              {itemUrl && (
-                <FormGroup>
-                  Loaded: <ControlLabel>{itemUrl}</ControlLabel>
-                </FormGroup>
-              )}
+              <InputGroup>
+                <div className="import-sub-title">
+                  (Optional) Import from a data.world URL:
+                </div>              
+                  <div className="select-item-container">
+                    <FormControl
+                      className="select-item-field"
+                      placeholder={"Enter dataset or project URL"}
+                      value={itemUrl}
+                      type="text"
+                      onChange={(event) => {
+                        this.props.handleChange(event.target.value);
+                      }}
+                    />
+                  </div>
+              </InputGroup>
             </div>
           </FormGroup>
         )}                  

--- a/src/util.js
+++ b/src/util.js
@@ -101,25 +101,16 @@ export function generateChartError(charts, failedToLoad) {
 }
 
 export function getDestination(url) {
-  const parsedPartialUrl = url.split('/');
+  // Regex to handle MT, PI, and VPC domains
+  const regexMatch = /^(?:https:\/\/(?:[a-zA-Z0-9-]+\.)?(?:app\.)?data\.world\/)?([^/?#]+)\/([^/?#]+)$/;
+  const parsedUrl = url.match(regexMatch);
 
-  if (parsedPartialUrl.length === 2) {
+  if (parsedUrl) {
     return {
-      owner: parsedPartialUrl[0],
-      id: parsedPartialUrl[1]
+      owner: parsedUrl[1],
+      id: parsedUrl[2]
     };
   }
-
-  const regexMatch = /https:\/\/data\.world\/([^/?#]*)\/([^/?#]*)?/;
-  const parsedFullUrl = url.match(regexMatch);
-
-  if (parsedFullUrl) {
-    return {
-      owner: parsedFullUrl[1],
-      id: parsedFullUrl[2]
-    };
-  }
-
   return null;
 }
 


### PR DESCRIPTION
Bug Report: Users with a large number of datasets or projects (1000+) were unable to import data into Excel using the Excel Add-in. The issue occurred because we attempted to load their entire dataset/project list, which exceeded the page limit.

Solution: To resolve this, I replaced the "get all" method, previously handled in `componentDidMount`, with our Search API. This now allows users to filter and retrieve datasets/projects more efficiently by entering a search query and the relevant organization ID. 

https://dataworld.atlassian.net/browse/SENG-1