### PR TITLE
SENG-1  | updated getDestination regex to support multiple domains

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,9 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
 #### Run locally
 
-##### `npm start`
+`nvm use 6.17.1`
+
+`npm start`
 
 Runs the react app and server component in development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view the front end UI in the browser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
 #### Run locally
 
-##### `yarn start`
+##### `npm start`
 
 Runs the react app and server component in development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view the front end UI in the browser.
@@ -98,7 +98,9 @@ Server Side Optional Environment Variables
 
 When testing locally `HTTPS=true` must be set as the Office online site will not load an add-in via http.
 
-`HTTPS=true REACT_APP_OAUTH_URI=https://localhost:3001/authorize OAUTH_REDIRECT_URI=https://localhost:3001/callback OAUTH_CLIENT_ID=excel-add-in-local OAUTH_CLIENT_SECRET=XXXX yarn start`
+```
+HTTPS=true REACT_APP_OAUTH_URI=https://localhost:3001/authorize OAUTH_REDIRECT_URI=https://localhost:3001/callback OAUTH_CLIENT_ID=excel-add-in-local OAUTH_CLIENT_SECRET=XXXX npm start
+```
 
 #### Testing against Office Online
 

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "url": "git+https://github.com/datadotworld/excel-add-in.git"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
-  "proxy": "http://localhost:3001"
+  "proxy": "http://localhost:3001",
+  "engines": {
+    "node": "6.17.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
     "url": "git+https://github.com/datadotworld/excel-add-in.git"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
-  "proxy": "http://localhost:3001",
-  "engines": {
-    "node": "6.17.1"
-  }
+  "proxy": "http://localhost:3001"
 }

--- a/src/tests/util.spec.js
+++ b/src/tests/util.spec.js
@@ -22,8 +22,41 @@ import {
   hasDuplicateName,
   createWorkspaceLink,
   createItemLink,
-  withWriteAccess
+  withWriteAccess,
+  getDestination
 } from '../util';
+
+describe('getDestination', () => {
+  it('should return dataset details given a URL or slug', () => {
+    const dataset = { owner: 'owner', id: 'dataset' };
+
+    const slug = 'owner/dataset';
+    const singleTenantUrl = 'https://customer.data.world/owner/dataset';
+    const singleTenantUrlWithParams =
+      'https://customer.data.world/owner/dataset/?first=foo&second=bar';
+    const multiTenantUrl = 'https://data.world/owner/dataset';
+    const multiTenantUrlWithParams =
+      'https://data.world/owner/dataset/?first=foo&second=bar';
+    const privateInstanceUrl =
+      'https://internal.app.data.world/owner/dataset';
+    const privateInstanceUrlWithParams =
+      'https://internal.app.data.world/owner/dataset/?first=foo&second=bar';
+
+    const invalidSlug = 'invalid/dataset/slug';
+    const invalidUrl = 'https://randomwebsite.com/owner/dataset';
+
+    expect(getDestination(slug)).toEqual(dataset);
+    expect(getDestination(singleTenantUrl)).toEqual(dataset);
+    expect(getDestination(singleTenantUrlWithParams)).toEqual(dataset);
+    expect(getDestination(multiTenantUrl)).toEqual(dataset);
+    expect(getDestination(multiTenantUrlWithParams)).toEqual(dataset);
+    expect(getDestination(privateInstanceUrl)).toEqual(dataset);
+    expect(getDestination(privateInstanceUrlWithParams)).toEqual(dataset);
+
+    expect(getDestination(invalidSlug)).toEqual(null);
+    expect(getDestination(invalidUrl)).toEqual(null);
+  });
+});
 
 describe('util functions', () => {
   describe('sortByOwnerAndTitle', () => {

--- a/src/tests/util.spec.js
+++ b/src/tests/util.spec.js
@@ -26,39 +26,39 @@ import {
   getDestination
 } from '../util';
 
-describe('getDestination', () => {
-  it('should return dataset details given a URL or slug', () => {
-    const dataset = { owner: 'owner', id: 'dataset' };
-
-    const slug = 'owner/dataset';
-    const singleTenantUrl = 'https://customer.data.world/owner/dataset';
-    const singleTenantUrlWithParams =
-      'https://customer.data.world/owner/dataset/?first=foo&second=bar';
-    const multiTenantUrl = 'https://data.world/owner/dataset';
-    const multiTenantUrlWithParams =
-      'https://data.world/owner/dataset/?first=foo&second=bar';
-    const privateInstanceUrl =
-      'https://internal.app.data.world/owner/dataset';
-    const privateInstanceUrlWithParams =
-      'https://internal.app.data.world/owner/dataset/?first=foo&second=bar';
-
-    const invalidSlug = 'invalid/dataset/slug';
-    const invalidUrl = 'https://randomwebsite.com/owner/dataset';
-
-    expect(getDestination(slug)).toEqual(dataset);
-    expect(getDestination(singleTenantUrl)).toEqual(dataset);
-    expect(getDestination(singleTenantUrlWithParams)).toEqual(dataset);
-    expect(getDestination(multiTenantUrl)).toEqual(dataset);
-    expect(getDestination(multiTenantUrlWithParams)).toEqual(dataset);
-    expect(getDestination(privateInstanceUrl)).toEqual(dataset);
-    expect(getDestination(privateInstanceUrlWithParams)).toEqual(dataset);
-
-    expect(getDestination(invalidSlug)).toEqual(null);
-    expect(getDestination(invalidUrl)).toEqual(null);
-  });
-});
-
 describe('util functions', () => {
+  describe('getDestination', () => {
+    it('should return dataset details given a URL or slug', () => {
+      const dataset = { owner: 'owner', id: 'dataset' };
+  
+      const slug = 'owner/dataset';
+      const singleTenantUrl = 'https://customer.data.world/owner/dataset';
+      const singleTenantUrlWithParams =
+        'https://customer.data.world/owner/dataset/?first=foo&second=bar';
+      const multiTenantUrl = 'https://data.world/owner/dataset';
+      const multiTenantUrlWithParams =
+        'https://data.world/owner/dataset/?first=foo&second=bar';
+      const privateInstanceUrl =
+        'https://internal.app.data.world/owner/dataset';
+      const privateInstanceUrlWithParams =
+        'https://internal.app.data.world/owner/dataset/?first=foo&second=bar';
+  
+      const invalidSlug = 'invalid/dataset/slug';
+      const invalidUrl = 'https://randomwebsite.com/owner/dataset';
+  
+      expect(getDestination(slug)).toEqual(dataset);
+      expect(getDestination(singleTenantUrl)).toEqual(dataset);
+      expect(getDestination(singleTenantUrlWithParams)).toEqual(dataset);
+      expect(getDestination(multiTenantUrl)).toEqual(dataset);
+      expect(getDestination(multiTenantUrlWithParams)).toEqual(dataset);
+      expect(getDestination(privateInstanceUrl)).toEqual(dataset);
+      expect(getDestination(privateInstanceUrlWithParams)).toEqual(dataset);
+  
+      expect(getDestination(invalidSlug)).toEqual(null);
+      expect(getDestination(invalidUrl)).toEqual(null);
+    });
+  });
+  
   describe('sortByOwnerAndTitle', () => {
     it('should sort datasets from the same owner by title', () => {
       const datasets = [

--- a/src/util.js
+++ b/src/util.js
@@ -101,15 +101,32 @@ export function generateChartError(charts, failedToLoad) {
 }
 
 export function getDestination(url) {
-  const regexMatch = /^(?:https:\/\/(?:[a-zA-Z0-9-]+\.)?(?:app\.)?data\.world\/)?([^/?#]+)\/([^/?#]+)$/;
+  // Regular expression to match full URLs with the format:
+  // https://*app.data.world/owner/id
+  // https://*.data.world/owner/id
+  // https://data.world/owner/id
+  const regexMatch = /^(?:https:\/\/(?:[a-zA-Z0-9-]+\.)?(?:app\.)?data\.world\/)([^/?#]+)\/([^/?#]+)(?:[/?#]|$)/;
   const parsedUrl = url.match(regexMatch);
 
   if (parsedUrl) {
+    // Matches full URL format
     return {
       owner: parsedUrl[1],
       id: parsedUrl[2]
-    }
-  };
+    };
+  }
+
+  // Regular expression to match 'owner/id' format
+  const partialRegex = /^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)$/;
+  const partialMatch = url.match(partialRegex);
+
+  if (partialMatch) {
+    return {
+      owner: partialMatch[1],
+      id: partialMatch[2]
+    };
+  }
+
   return null;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -100,7 +100,6 @@ export function generateChartError(charts, failedToLoad) {
   }
 }
 
-// NEW
 export function getDestination(url) {
   const regexMatch = /^(?:https:\/\/(?:[a-zA-Z0-9-]+\.)?(?:app\.)?data\.world\/)?([^/?#]+)\/([^/?#]+)$/;
   const parsedUrl = url.match(regexMatch);
@@ -113,29 +112,6 @@ export function getDestination(url) {
   };
   return null;
 }
-
-// export function getDestination(url) {
-//   const parsedPartialUrl = url.split('/');
-
-//   if (parsedPartialUrl.length === 2) {
-//     return {
-//       owner: parsedPartialUrl[0],
-//       id: parsedPartialUrl[1]
-//     };
-//   }
-
-//   const regexMatch = /https:\/\/data\.world\/([^/?#]*)\/([^/?#]*)?/;
-//   const parsedFullUrl = url.match(regexMatch);
-
-//   if (parsedFullUrl) {
-//     return {
-//       owner: parsedFullUrl[1],
-//       id: parsedFullUrl[2]
-//     };
-//   }
-
-//   return null;
-// }
 
 export function sortByOwnerAndTitle(datasets) {
   return datasets.sort((a, b) => {

--- a/src/util.js
+++ b/src/util.js
@@ -100,28 +100,42 @@ export function generateChartError(charts, failedToLoad) {
   }
 }
 
+// NEW
 export function getDestination(url) {
-  const parsedPartialUrl = url.split('/');
+  const regexMatch = /^(?:https:\/\/(?:[a-zA-Z0-9-]+\.)?(?:app\.)?data\.world\/)?([^/?#]+)\/([^/?#]+)$/;
+  const parsedUrl = url.match(regexMatch);
 
-  if (parsedPartialUrl.length === 2) {
+  if (parsedUrl) {
     return {
-      owner: parsedPartialUrl[0],
-      id: parsedPartialUrl[1]
-    };
-  }
-
-  const regexMatch = /https:\/\/data\.world\/([^/?#]*)\/([^/?#]*)?/;
-  const parsedFullUrl = url.match(regexMatch);
-
-  if (parsedFullUrl) {
-    return {
-      owner: parsedFullUrl[1],
-      id: parsedFullUrl[2]
-    };
-  }
-
+      owner: parsedUrl[1],
+      id: parsedUrl[2]
+    }
+  };
   return null;
 }
+
+// export function getDestination(url) {
+//   const parsedPartialUrl = url.split('/');
+
+//   if (parsedPartialUrl.length === 2) {
+//     return {
+//       owner: parsedPartialUrl[0],
+//       id: parsedPartialUrl[1]
+//     };
+//   }
+
+//   const regexMatch = /https:\/\/data\.world\/([^/?#]*)\/([^/?#]*)?/;
+//   const parsedFullUrl = url.match(regexMatch);
+
+//   if (parsedFullUrl) {
+//     return {
+//       owner: parsedFullUrl[1],
+//       id: parsedFullUrl[2]
+//     };
+//   }
+
+//   return null;
+// }
 
 export function sortByOwnerAndTitle(datasets) {
   return datasets.sort((a, b) => {


### PR DESCRIPTION
Bug Report: The current regex used in `getDestination` assumes the domain `https://data.world/owner/id` 

Solution: To resolve this, I replaced the regex with support for:
- `https://data.world/owner/id`
- `https://*.app.data.world/owner/id`
- `https://*.data.world/owner/id`

https://dataworld.atlassian.net/browse/SENG-1