### PR TITLE
SNEG-17 | added baseUrl generation to uploadInsight

### DIFF
--- a/src/DataDotWorldApi.js
+++ b/src/DataDotWorldApi.js
@@ -151,7 +151,6 @@ export default class DataDotWorldApi {
         imageUrl: imageUrl
       }
     });
-  
     return uri;
   }
 

--- a/src/DataDotWorldApi.js
+++ b/src/DataDotWorldApi.js
@@ -135,18 +135,23 @@ export default class DataDotWorldApi {
   async uploadInsight(options) {
     const { title, project, description } = options;
     const uriTitle = encodeURIComponent(title);
+  
+    const user = await this.getUser();
+    const baseUrl = user.baseUrl;
+  
+    // Dynamically construct imageUrl based on the User object
+    const imageUrl = `${baseUrl}/api/${project.owner}/dataset/${project.id}/file/raw/${uriTitle}.png`;
+  
     const {
       data: { uri }
     } = await this.api.post(`/insights/${project.owner}/${project.id}`, {
       title,
       description,
       body: {
-        imageUrl: `https://data.world/api/${project.owner}/dataset/${
-          project.id
-        }/file/raw/${uriTitle}.png`
+        imageUrl: imageUrl
       }
     });
-
+  
     return uri;
   }
 

--- a/src/components/UploadInsight.js
+++ b/src/components/UploadInsight.js
@@ -99,7 +99,7 @@ class UploadInsight extends Component {
     return (
       <div>
         <Row className="center-block section-header insight-header">
-          <div className="insight-title">New Insighst</div>
+          <div className="insight-title">New Insight</div>
         </Row>
         <Row className="upload-row">
           {!uploadComplete && (

--- a/src/tests/components/__snapshots__/UploadInsight.spec.js.snap
+++ b/src/tests/components/__snapshots__/UploadInsight.spec.js.snap
@@ -8,7 +8,7 @@ exports[`renders upload insight view 1`] = `
     <div
       className="insight-title"
     >
-      New Insighst
+      New Insight
     </div>
   </div>
   <div


### PR DESCRIPTION
https://dataworld.atlassian.net/browse/SENG-17

Bug Report: 
When importing Charts from Excel to data.world we are hardcoding the `imageUrl` that breaks PI/VPC images

Solution:
Generate the `baseUrl` from the User object then pass this to the `imageUrl`