### PR TITLE
adding dynamic baseURL for API

### DIFF
--- a/src/DataDotWorldApi.js
+++ b/src/DataDotWorldApi.js
@@ -22,6 +22,7 @@ import { b64toBlob, groupAndSortProjects, withWriteAccess } from './util';
 
 export default class DataDotWorldApi {
   constructor(token) {
+    const baseURL = process.env.API_BASE_URL || 'https://api.data.world/v0';
     this.api = axios.create({
       baseURL: 'https://api.data.world/v0',
       headers: {

--- a/src/DataDotWorldApi.js
+++ b/src/DataDotWorldApi.js
@@ -24,7 +24,7 @@ export default class DataDotWorldApi {
   constructor(token) {
     const baseURL = process.env.API_BASE_URL || 'https://api.data.world/v0';
     this.api = axios.create({
-      baseURL: 'https://api.data.world/v0',
+      baseURL: baseURL,
       headers: {
         Authorization: `Bearer ${token}`
       }


### PR DESCRIPTION
# Description
This allows the DataDotWorldApi class to dynamically set the URL based on the environment provided by the deployment wrapper, ensuring that the application can switch between different API endpoints without relying on hardcoded values.